### PR TITLE
MihaiOnSoftware/update tags for version 6

### DIFF
--- a/assets/props/Engines/engine_spl_m_large.xml
+++ b/assets/props/Engines/engine_spl_m_large.xml
@@ -120,7 +120,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="EngineConnection01" tags="engine mediumlarge component ">
+			<connection name="EngineConnection01" tags="engine mediumlarge component standard">
 				<offset/>
 			</connection>
 			<connection name="enginealign" tags="enginealign ">

--- a/assets/props/WeaponSystems/dumbfire/weapon_gen_m_dumbfire_01_mk1.xml
+++ b/assets/props/WeaponSystems/dumbfire/weapon_gen_m_dumbfire_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium missile standard">
+<connection name="WeaponCon_01" tags="component weapon medium missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/dumbfire/weapon_gen_m_dumbfire_01_mk2.xml
+++ b/assets/props/WeaponSystems/dumbfire/weapon_gen_m_dumbfire_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium missile standard">
+<connection name="WeaponCon_01" tags="component weapon medium missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/dumbfire/weapon_gen_s_dumbfire_01_mk1.xml
+++ b/assets/props/WeaponSystems/dumbfire/weapon_gen_s_dumbfire_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small missile standard">
+<connection name="WeaponCon_01" tags="component weapon small missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/dumbfire/weapon_gen_s_dumbfire_01_mk2.xml
+++ b/assets/props/WeaponSystems/dumbfire/weapon_gen_s_dumbfire_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small missile standard">
+<connection name="WeaponCon_01" tags="component weapon small missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/turret_arg_l_beam_powered.xml
+++ b/assets/props/WeaponSystems/energy/turret_arg_l_beam_powered.xml
@@ -409,7 +409,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_turret_beam_l" tags="turret large highpower argonly component">
+			<connection name="con_turret_beam_l" tags="turret large highpower argonly component combat">
 				<offset/>
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/energy/turret_par_l_beam_powered.xml
+++ b/assets/props/WeaponSystems/energy/turret_par_l_beam_powered.xml
@@ -302,7 +302,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_turret_beam_l" tags="turret large highpower paronly component">
+			<connection name="con_turret_beam_l" tags="turret large highpower paronly component combat">
 				<offset/>
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/energy/turret_tel_l_beam_powered.xml
+++ b/assets/props/WeaponSystems/energy/turret_tel_l_beam_powered.xml
@@ -407,7 +407,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_turret_beam_l" tags="turret large highpower telonly component">
+			<connection name="con_turret_beam_l" tags="turret large highpower telonly component combat">
 				<offset/>
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/energy/weapon_arg_m_ion_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_arg_m_ion_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_arg_s_ion_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_arg_s_ion_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_m_beam_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_m_beam_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_m_beam_01_mk2.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_m_beam_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_m_burst_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_m_burst_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_002']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_s_beam_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_s_beam_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_s_beam_01_mk2.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_s_beam_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/energy/weapon_gen_s_burst_01_mk1.xml
+++ b/assets/props/WeaponSystems/energy/weapon_gen_s_burst_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/guided/cruisemissile_l_turret_comp.xml
+++ b/assets/props/WeaponSystems/guided/cruisemissile_l_turret_comp.xml
@@ -280,7 +280,7 @@
 				</parts>
 			</connection>
 			<!-- <connection name="con_turret_dumbfire_l" tags="turret large missile component"> -->
-			<connection name="con_turret_dumbfire_l" tags="turret large standard component">
+			<connection name="con_turret_dumbfire_l" tags="turret large standard component combat">
 				<offset />
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/guided/cruisemissile_l_xen_turret_comp.xml
+++ b/assets/props/WeaponSystems/guided/cruisemissile_l_xen_turret_comp.xml
@@ -280,7 +280,7 @@
 				</parts>
 			</connection>
 			<!-- <connection name="con_turret_dumbfire_l" tags="turret large missile component"> -->
-			<connection name="con_turret_dumbfire_l" tags="turret large standard xcruise component">
+			<connection name="con_turret_dumbfire_l" tags="turret large standard xcruise component combat">
 				<offset />
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/guided/weapon_gen_m_guided_01_mk1.xml
+++ b/assets/props/WeaponSystems/guided/weapon_gen_m_guided_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium missile standard">
+<connection name="WeaponCon_01" tags="component weapon medium missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/guided/weapon_gen_m_guided_01_mk2.xml
+++ b/assets/props/WeaponSystems/guided/weapon_gen_m_guided_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium missile standard">
+<connection name="WeaponCon_01" tags="component weapon medium missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/guided/weapon_gen_s_guided_01_mk1.xml
+++ b/assets/props/WeaponSystems/guided/weapon_gen_s_guided_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small missile standard">
+<connection name="WeaponCon_01" tags="component weapon small missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/guided/weapon_gen_s_guided_01_mk2.xml
+++ b/assets/props/WeaponSystems/guided/weapon_gen_s_guided_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small missile standard">
+<connection name="WeaponCon_01" tags="component weapon small missile standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_m_cannon_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_m_cannon_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_m_gatling_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_m_gatling_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_m_gatling_01_mk2.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_m_gatling_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_s_cannon_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_s_cannon_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_s_gatling_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_s_gatling_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_gen_s_gatling_01_mk2.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_gen_s_gatling_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_par_m_railgun_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_par_m_railgun_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_par_s_railgun_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_par_s_railgun_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_tel_m_charge_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_tel_m_charge_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/heavy/weapon_tel_s_charge_01_mk1.xml
+++ b/assets/props/WeaponSystems/heavy/weapon_tel_s_charge_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/missile/missile_cruise.xml
+++ b/assets/props/WeaponSystems/missile/missile_cruise.xml
@@ -128,7 +128,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine01" tags="engine ">
+			<connection name="con_engine01" tags="engine standard">
 				<offset>
 					<position x="0" y="0" z="-1.848475"/>
 				</offset>

--- a/assets/props/WeaponSystems/missile/missile_heavy.xml
+++ b/assets/props/WeaponSystems/missile/missile_heavy.xml
@@ -91,7 +91,7 @@
 				<offset/>
 				<parts/>
 			</connection>
-			<connection name="con_engine01" tags="engine ">
+			<connection name="con_engine01" tags="engine standard">
 				<offset>
 					<position x="0" y="0" z="-0.8024648"/>
 				</offset>

--- a/assets/props/WeaponSystems/missile/missile_heavy_swarm.xml
+++ b/assets/props/WeaponSystems/missile/missile_heavy_swarm.xml
@@ -91,7 +91,7 @@
 				<offset/>
 				<parts/>
 			</connection>
-			<connection name="con_engine01" tags="engine ">
+			<connection name="con_engine01" tags="engine standard">
 				<offset>
 					<position x="0" y="0" z="-0.8024648"/>
 				</offset>

--- a/assets/props/WeaponSystems/missile/missile_medium.xml
+++ b/assets/props/WeaponSystems/missile/missile_medium.xml
@@ -91,7 +91,7 @@
 				<offset/>
 				<parts/>
 			</connection>
-			<connection name="con_engine01" tags="engine ">
+			<connection name="con_engine01" tags="engine standard">
 				<offset>
 					<position x="0" y="0" z="-0.8024648"/>
 				</offset>

--- a/assets/props/WeaponSystems/missile/missile_xen_light_comp.xml
+++ b/assets/props/WeaponSystems/missile/missile_xen_light_comp.xml
@@ -91,7 +91,7 @@
 				<offset/>
 				<parts/>
 			</connection>
-			<connection name="con_engine01" tags="engine ">
+			<connection name="con_engine01" tags="engine standard">
 				<offset>
 					<position x="0" y="0" z="-0.8024648"/>
 				</offset>

--- a/assets/props/WeaponSystems/standard/weapon_gen_m_laser_01_mk1.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_m_laser_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/standard/weapon_gen_m_laser_01_mk2.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_m_laser_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/standard/weapon_gen_m_shotgun_01_mk1.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_m_shotgun_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon medium standard ">
+<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/standard/weapon_gen_s_laser_01_mk1.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_s_laser_01_mk1.xml
@@ -2,7 +2,7 @@
 
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>
@@ -261,7 +261,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="WeaponCon_01" tags="component weapon small standard ">
+			<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 			</connection>
 		</connections>

--- a/assets/props/WeaponSystems/standard/weapon_gen_s_laser_01_mk2.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_s_laser_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/standard/weapon_gen_s_shotgun_01_mk1.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_s_shotgun_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon small standard ">
+<connection name="WeaponCon_01" tags="component weapon small standard combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/props/WeaponSystems/standard/weapon_gen_s_shotgun_01_mk2.xml
+++ b/assets/props/WeaponSystems/standard/weapon_gen_s_shotgun_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-<connection name="WeaponCon_01" tags="component weapon standard small ">
+<connection name="WeaponCon_01" tags="component weapon standard small combat">
 				<offset/>
 </connection>
 </replace>

--- a/assets/structures/defence/defence_arg_disc_01.xml
+++ b/assets/structures/defence/defence_arg_disc_01.xml
@@ -402,12 +402,12 @@
 					<quaternion qx="-1.042161E-14" qy="2.384186E-07" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05" tags="large shield standard">
 				<offset>
 					<position x="-66.43057" y="60.81914" z="-2.403775E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06" tags="large shield standard">
 				<offset>
 					<position x="66.1926" y="60.81914" z="-2.403775E-03"/>
 				</offset>
@@ -530,13 +530,13 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield standard">
 				<offset>
 					<position x="66.1926" y="-60.61668" z="-2.406191E-03"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield ">
+			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield standard">
 				<offset>
 					<position x="-66.43057" y="-60.61668" z="-2.406191E-03"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>

--- a/assets/structures/defence/defence_arg_disc_01.xml
+++ b/assets/structures/defence/defence_arg_disc_01.xml
@@ -380,23 +380,23 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-16.94558" y="70.33514" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="16.61921" y="70.33514" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="17.29245" y="-70.26517" z="0"/>
 					<quaternion qx="-1.042161E-14" qy="2.384186E-07" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-17.10529" y="-70.26517" z="0"/>
 					<quaternion qx="-1.042161E-14" qy="2.384186E-07" qz="-1" qw="4.371139E-08"/>
@@ -412,96 +412,96 @@
 					<position x="66.1926" y="60.81914" z="-2.403775E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-132.2654" y="58.87038" z="-37.62078"/>
 					<quaternion qx="6.162845E-02" qy="-0.704416" qz="-6.162841E-02" qw="-0.704416"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-132.2654" y="58.87038" z="37.78549"/>
 					<quaternion qx="6.162845E-02" qy="-0.704416" qz="-6.162841E-02" qw="-0.704416"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="133.0821" y="58.87035" z="-37.62078"/>
 					<quaternion qx="-6.162841E-02" qy="-0.704416" qz="6.162841E-02" qw="-0.704416"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="133.0822" y="58.87037" z="37.78549"/>
 					<quaternion qx="-6.162848E-02" qy="-0.7044151" qz="6.162833E-02" qw="-0.7044169"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-38.46902" y="58.87035" z="133.1077"/>
 					<quaternion qx="-8.715573E-02" qy="8.70901E-08" qz="-7.619396E-09" qw="-0.9961947"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="36.93726" y="58.87036" z="133.1077"/>
 					<quaternion qx="-8.715573E-02" qy="8.70901E-08" qz="-7.619396E-09" qw="-0.9961947"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-38.46902" y="58.87035" z="-130.3909"/>
 					<quaternion qx="-1.419948E-08" qy="-0.9961947" qz="0.0871558" qw="-1.623007E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="36.93726" y="58.87035" z="-130.3909"/>
 					<quaternion qx="-1.419948E-08" qy="-0.9961947" qz="0.0871558" qw="-1.623007E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="76.95073" z="-33.25202"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="76.95073" z="-55.2057"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="76.95073" z="33.64053"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="76.95073" z="55.40681"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-76.88075" z="33.64053"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-76.88075" z="55.40681"/>
 					<quaternion qx="-1" qy="7.54979E-08" qz="-4.371139E-08" qw="3.300118E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-76.88075" z="-33.22974"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-76.88075" z="-54.99601"/>
 					<quaternion qx="-1" qy="7.54979E-08" qz="-4.371139E-08" qw="3.300118E-15"/>
@@ -542,49 +542,49 @@
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_009" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_009" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="36.93726" y="-59.02637" z="131.8316"/>
 					<quaternion qx="1.623007E-07" qy="-0.087156" qz="-0.9961946" qw="-1.419952E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_010" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_010" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-38.46902" y="-59.02637" z="131.8316"/>
 					<quaternion qx="1.623007E-07" qy="-0.087156" qz="-0.9961946" qw="-1.419952E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_011" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_011" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="36.93726" y="-59.02643" z="-131.6669"/>
 					<quaternion qx="-0.9961947" qy="-7.619398E-09" qz="-8.70901E-08" qw="8.715576E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_012" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_012" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-38.46902" y="-59.02642" z="-131.6669"/>
 					<quaternion qx="-0.9961947" qy="-7.619398E-09" qz="-8.70901E-08" qw="8.715576E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="133.0822" y="-59.02642" z="-36.34473"/>
 					<quaternion qx="-0.7044151" qy="-6.162846E-02" qz="-0.7044169" qw="6.162836E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="133.0821" y="-59.02639" z="39.06155"/>
 					<quaternion qx="-0.704416" qy="-6.162838E-02" qz="-0.704416" qw="6.162844E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-132.2654" y="-59.02643" z="-36.34473"/>
 					<quaternion qx="-0.704416" qy="6.162851E-02" qz="-0.704416" qw="-6.162845E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-132.2654" y="-59.02641" z="39.06155"/>
 					<quaternion qx="-0.704416" qy="6.162851E-02" qz="-0.704416" qw="-6.162845E-02"/>

--- a/assets/structures/defence/defence_arg_tube_01.xml
+++ b/assets/structures/defence/defence_arg_tube_01.xml
@@ -358,23 +358,23 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="51.16601" z="99.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="51.081" z="-99.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="-51.19204" z="-99.5"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="-51.19204" z="99.5"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
@@ -391,95 +391,95 @@
 					<quaternion qx="-1" qy="-0" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-98.3983" y="33.44613" z="99.30336"/>
 					<quaternion qx="1.40574E-08" qy="5.246292E-08" qz="-0.258819" qw="-0.9659259"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-98.3983" y="33.44613" z="-100.1844"/>
 					<quaternion qx="1.40574E-08" qy="5.246292E-08" qz="-0.258819" qw="-0.9659259"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="99.27937" y="33.44613" z="99.12463"/>
 					<quaternion qx="-0.258819" qy="-0.9659259" qz="1.954029E-08" qw="7.292539E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="99.27937" y="33.44613" z="-100.1844"/>
 					<quaternion qx="-0.258819" qy="-0.9659259" qz="1.954029E-08" qw="7.292539E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="-98.71429" y="-32.63222" z="99.23383"/>
 					<quaternion qx="3.455373E-07" qy="3.455373E-07" qz="-0.9659258" qw="-0.2588192"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="-98.71429" y="-32.63222" z="-100.036"/>
 					<quaternion qx="3.455373E-07" qy="3.455373E-07" qz="-0.9659258" qw="-0.2588192"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="99.27937" y="-32.63222" z="99.12463"/>
 					<quaternion qx="-0.9659259" qy="-0.258819" qz="4.216697E-08" qw="1.573693E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="99.27937" y="-32.63222" z="-100.036"/>
 					<quaternion qx="-0.9659259" qy="-0.258819" qz="4.216697E-08" qw="1.573693E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="53.12622" z="-55.10382"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="53.12622" z="-144.9718"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="53.21123" z="54.77449"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="53.21123" z="144.6425"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-6.03983E-07" y="-53.2205" z="54.77449"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-6.03983E-07" y="-53.2205" z="144.6425"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-6.03983E-07" y="-53.2205" z="-144.9718"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-6.03983E-07" y="-53.2205" z="-55.10382"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/assets/structures/defence/defence_arg_tube_01.xml
+++ b/assets/structures/defence/defence_arg_tube_01.xml
@@ -380,12 +380,12 @@
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05" tags="large shield standard">
 				<offset>
 					<position x="0" y="43.95404" z="-1.45192E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06" tags="large shield standard">
 				<offset>
 					<position x="0" y="-43.94441" z="-2.405488E-03"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="7.54979E-08"/>

--- a/assets/structures/defence/defence_par_disc_01.xml
+++ b/assets/structures/defence/defence_par_disc_01.xml
@@ -376,12 +376,12 @@
 					<position x="3.781939E-02" y="124.5155" z="-43.70469"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group02 " tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group02 " tags="large shield standard">
 				<offset>
 					<position x="0" y="106.5906" z="98.19112"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group02 " tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group02 " tags="large shield standard">
 				<offset>
 					<position x="0" y="106.5906" z="-96.43858"/>
 				</offset>
@@ -443,13 +443,13 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group01  " tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group01  " tags="large shield standard">
 				<offset>
 					<position x="0" y="-106.5168" z="-96.43858"/>
 					<quaternion qx="-1.629207E-07" qy="7.54979E-08" qz="-1" qw="-1.230017E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group01  " tags="large shield ">
+			<connection name="con_shieldgen_large_004" group="group01  " tags="large shield standard">
 				<offset>
 					<position x="0" y="-106.5168" z="97.18811"/>
 					<quaternion qx="-1.629207E-07" qy="7.54979E-08" qz="-1" qw="-1.230017E-14"/>

--- a/assets/structures/defence/defence_par_disc_01.xml
+++ b/assets/structures/defence/defence_par_disc_01.xml
@@ -366,12 +366,12 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group05 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group05 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="4.963684E-02" y="124.2974" z="45.44719"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group06 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group06 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="3.781939E-02" y="124.5155" z="-43.70469"/>
 				</offset>
@@ -386,35 +386,35 @@
 					<position x="0" y="106.5906" z="-96.43858"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="121.1466" y="60.55534" z="-122.2827"/>
 					<quaternion qx="-0.2705981" qy="-0.6532815" qz="0.6532813" qw="-0.2705982"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group01 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group01 " tags="turret large standard missile combat">
 				<offset>
 					<position x="121.1465" y="-59.44466" z="-122.2827"/>
 					<quaternion qx="0.2705982" qy="0.6532814" qz="-0.6532815" qw="0.2705981"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group05 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group05 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-28.96403" y="145.9298" z="0.5495324"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group06 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group06 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="28.77529" y="145.9298" z="0.54953"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group06 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group06 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="113.1617" z="-186.4823"/>
 					<quaternion qx="2.889179E-08" qy="-0.9238796" qz="0.3826834" qw="6.975097E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group05 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group05 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="113.0023" z="186.6214"/>
 					<quaternion qx="-2.889179E-08" qy="-0.9238796" qz="-0.3826834" qw="6.975097E-08"/>
@@ -455,13 +455,13 @@
 					<quaternion qx="-1.629207E-07" qy="7.54979E-08" qz="-1" qw="-1.230017E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group01 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group01 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-121.0639" y="-59.44469" z="119.9272"/>
 					<quaternion qx="-0.6532814" qy="0.2705985" qz="-0.2705983" qw="-0.6532813"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-121.0655" y="60.5553" z="119.9291"/>
 					<quaternion qx="-0.6532815" qy="0.2705982" qz="-0.2705981" qw="-0.6532815"/>
@@ -472,85 +472,85 @@
 					<position x="0" y="198.282" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group01 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group01 " tags="turret large standard missile combat">
 				<offset>
 					<position x="121.1464" y="-59.44466" z="119.9283"/>
 					<quaternion qx="-0.6532817" qy="-0.2705977" qz="0.2705978" qw="-0.6532816"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-121.0655" y="60.5553" z="-122.2837"/>
 					<quaternion qx="0.2705978" qy="-0.6532816" qz="0.6532816" qw="0.2705977"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group01 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group01 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-121.0635" y="-59.44469" z="-122.2821"/>
 					<quaternion qx="0.2705975" qy="-0.6532817" qz="0.6532817" qw="0.2705975"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="121.1464" y="60.55534" z="119.9283"/>
 					<quaternion qx="-0.6532816" qy="-0.2705979" qz="0.270598" qw="-0.6532814"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_009" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_009" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="82.34479" y="148.6284" z="0"/>
 					<quaternion qx="-0" qy="0.7071067" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_010" group="group02 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_010" group="group02 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-79.83333" y="148.5885" z="0"/>
 					<quaternion qx="-0" qy="-0.7071069" qz="-0" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_011" group="group01 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_011" group="group01 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-79.83333" y="-148.616" z="-1.470631E-12"/>
 					<quaternion qx="0.7071066" qy="-5.338509E-08" qz="-0.7071069" qw="-5.338507E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_012" group="group01  " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_012" group="group01  " tags="turret large standard missile combat">
 				<offset>
 					<position x="82.34479" y="-148.6315" z="-1.470631E-12"/>
 					<quaternion qx="-0.7071068" qy="-5.338508E-08" qz="-0.7071067" qw="5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group08" tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group08" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-3.245258E-02" y="-124.1146" z="-45.1386"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group07" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group07" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="29.53324" y="-146.0004" z="-7.823896E-02"/>
 					<quaternion qx="0.7071067" qy="-3.090862E-08" qz="-0.7071068" qw="3.090862E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group08" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group08" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-29.40153" y="-145.9998" z="2.193451E-03"/>
 					<quaternion qx="-0.7071068" qy="3.090862E-08" qz="-0.7071067" qw="3.090862E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group07" tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group07" tags="medium shield hittable standard ">
 				<offset>
 					<position x="3.765583E-02" y="-123.998" z="45.72721"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group07" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group07" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-113.3274" z="186.2917"/>
 					<quaternion qx="1.672762E-08" qy="-0.3826834" qz="-0.9238796" qw="4.038406E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group08" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group08" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-113.2554" z="-186.3526"/>
 					<quaternion qx="-0.9238796" qy="2.365644E-08" qz="-5.711168E-08" qw="0.3826834"/>

--- a/assets/structures/defence/defence_par_tube_01.xml
+++ b/assets/structures/defence/defence_par_tube_01.xml
@@ -263,13 +263,13 @@
 					<quaternion qx="0.4999998" qy="0.5" qz="0.5000001" qw="-0.4999999"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05 " tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05 " tags="large shield standard">
 				<offset>
 					<position x="-40.24823" y="0.1185074" z="-5.279732E-02"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06 " tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06 " tags="large shield standard">
 				<offset>
 					<position x="40.21236" y="0.1185074" z="-5.520248E-02"/>
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="5.338509E-08" qw="5.338508E-08"/>

--- a/assets/structures/defence/defence_par_tube_01.xml
+++ b/assets/structures/defence/defence_par_tube_01.xml
@@ -239,25 +239,25 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard">
 				<offset>
 					<position x="-45.9156" y="7.540989E-02" z="47.70412"/>
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard">
 				<offset>
 					<position x="-45.8306" y="7.540989E-02" z="-48.32287"/>
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard">
 				<offset>
 					<position x="45.82092" y="6.995392E-02" z="-47.32787"/>
 					<quaternion qx="0.4999998" qy="0.5" qz="0.5000001" qw="-0.4999999"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard">
 				<offset>
 					<position x="45.82092" y="6.995392E-02" z="47.79594"/>
 					<quaternion qx="0.4999998" qy="0.5" qz="0.5000001" qw="-0.4999999"/>
@@ -275,96 +275,96 @@
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="5.338509E-08" qw="5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-47.09863" y="93.78578" z="73.26709"/>
 					<quaternion qx="3.115301E-08" qy="4.44911E-08" qz="-0.5735765" qw="-0.819152"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-47.09863" y="93.78578" z="-72.0888"/>
 					<quaternion qx="3.115301E-08" qy="4.44911E-08" qz="-0.5735765" qw="-0.819152"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="47.21176" y="93.78578" z="73.08836"/>
 					<quaternion qx="-0.5735765" qy="-0.819152" qz="4.330381E-08" qw="6.184425E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="47.21176" y="93.78578" z="-72.0888"/>
 					<quaternion qx="-0.5735765" qy="-0.819152" qz="4.330381E-08" qw="6.184425E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-49.71148" y="-85.72198" z="73.19756"/>
 					<quaternion qx="3.929305E-07" qy="3.929305E-07" qz="-0.819152" qw="-0.5735765"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-49.71148" y="-85.72198" z="-71.94039"/>
 					<quaternion qx="3.929305E-07" qy="3.929305E-07" qz="-0.819152" qw="-0.5735765"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="50.2014" y="-85.72198" z="73.08836"/>
 					<quaternion qx="-0.819152" qy="-0.5735765" qz="9.344748E-08" qw="1.334568E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="50.2014" y="-85.72198" z="-71.94039"/>
 					<quaternion qx="-0.819152" qy="-0.5735765" qz="9.344748E-08" qw="1.334568E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.217293E-04" y="135.6404" z="-72.70784"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-45.87859" y="7.540989E-02" z="-73.30531"/>
 					<quaternion qx="-0.7071068" qy="0.7071068" qz="5.338508E-08" qw="-5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.217293E-04" y="135.7254" z="73.77089"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-45.84928" y="-2.056885E-02" z="73.50763"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0.1398067" y="-135.5822" z="73.39857"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="45.85963" y="6.995392E-02" z="73.60973"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="45.85963" y="6.995392E-02" z="-73.32904"/>
 					<quaternion qx="-0.7071068" qy="-0.7071067" qz="5.338509E-08" qw="5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0.1398067" y="-135.5822" z="-75.08172"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/assets/structures/defence/defence_tel_disc_01.xml
+++ b/assets/structures/defence/defence_tel_disc_01.xml
@@ -301,12 +301,12 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="64.65821" z="-152.9389"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group03" tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group03" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="64.68708" z="148.527"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
@@ -323,72 +323,72 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="96.33775" y="45.45737" z="96.31077"/>
 					<quaternion qx="-0.1999641" qy="-0.3736121" qz="0.0828278" qw="-0.90198"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-96.31076" y="45.45737" z="96.33775"/>
 					<quaternion qx="-0.1999641" qy="0.3736123" qz="-8.282783E-02" qw="-0.9019799"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-96.33775" y="45.45737" z="-96.31076"/>
 					<quaternion qx="8.282784E-02" qy="-0.9019799" qz="0.1999641" qw="0.3736123"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="96.31076" y="45.45737" z="-96.33775"/>
 					<quaternion qx="-8.282787E-02" qy="-0.9019799" qz="0.1999641" qw="-0.3736124"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="110.0479" y="-95.02549" z="-0.6428361"/>
 					<quaternion qx="-0.6841371" qy="-0.1459259" qz="-0.6973742" qw="0.1559848"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="54.46724" y="-95.02549" z="-95.6257"/>
 					<quaternion qx="-0.9411672" qy="-4.838317E-02" qz="-0.2618753" qw="0.2080496"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-55.58067" y="-95.02549" z="-94.98286"/>
 					<quaternion qx="-0.9460123" qy="6.212392E-02" qz="0.243793" qw="0.204368"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-110.0479" y="-95.02549" z="0.6428381"/>
 					<quaternion qx="-0.6973745" qy="0.1559848" qz="0.6841368" qw="0.145926"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="64.65821" z="-142.2057"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="64.65821" z="-164.1594"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="64.68708" z="136.6487"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="64.68708" z="158.415"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
@@ -429,13 +429,13 @@
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_009" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_009" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-54.46724" y="-95.02549" z="95.62569"/>
 					<quaternion qx="0.2618757" qy="-0.2080499" qz="-0.9411671" qw="-4.838328E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_010" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_010" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="55.58067" y="-95.02549" z="94.98286"/>
 					<quaternion qx="-0.2437926" qy="-0.2043679" qz="-0.9460124" qw="6.212372E-02"/>
@@ -446,37 +446,37 @@
 					<position x="0" y="94.71277" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="142.2057" y="64.65821" z="0"/>
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="164.1594" y="64.65821" z="0"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group04" tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group04" tags="medium shield hittable standard ">
 				<offset>
 					<position x="152.9389" y="64.65821" z="0"/>
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_011" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-136.6487" y="64.68708" z="0"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group02" tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group02" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-148.527" y="64.68708" z="0"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_012" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-158.415" y="64.68708" z="0"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071068"/>

--- a/assets/structures/defence/defence_tel_disc_01.xml
+++ b/assets/structures/defence/defence_tel_disc_01.xml
@@ -312,12 +312,12 @@
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05" tags="large shield standard">
 				<offset>
 					<position x="0.1947021" y="64.31032" z="-81.77507"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group05" tags="large shield standard">
 				<offset>
 					<position x="81.77507" y="64.31032" z="0.1947021"/>
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
@@ -417,13 +417,13 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group05" tags="large shield standard">
 				<offset>
 					<position x="-0.1947027" y="64.31032" z="81.77507"/>
 					<quaternion qx="4.371139E-08" qy="-1" qz="-7.54979E-08" qw="3.300118E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group05" tags="large shield">
+			<connection name="con_shieldgen_large_004" group="group05" tags="large shield standard">
 				<offset>
 					<position x="-81.77507" y="64.31032" z="-0.1947021"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071067"/>

--- a/assets/structures/defence/defence_tel_tube_01.xml
+++ b/assets/structures/defence/defence_tel_tube_01.xml
@@ -200,23 +200,23 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="88.67915" z="120.5941"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard">
 				<offset>
 					<position x="0" y="88.68649" z="-125.2651"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard">
 				<offset>
 					<position x="-4.48255E-07" y="-88.68108" z="-128.0672"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard">
 				<offset>
 					<position x="-4.48255E-07" y="-88.65761" z="126.4028"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
@@ -233,95 +233,95 @@
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-71.45493" y="58.76908" z="77.36266"/>
 					<quaternion qx="1.738283E-08" qy="7.840887E-08" qz="-0.2164396" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-71.45493" y="58.76908" z="-76.77099"/>
 					<quaternion qx="0.2164396" qy="-0.976296" qz="-6.69258E-07" qw="-2.241973E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="71.72193" y="58.76908" z="77.36266"/>
 					<quaternion qx="3.268149E-08" qy="-1.474166E-07" qz="0.2164397" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group05 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group05 " tags="turret large standard missile combat">
 				<offset>
 					<position x="71.72191" y="58.76908" z="-76.77098"/>
 					<quaternion qx="-0.2164396" qy="-0.976296" qz="1.634073E-08" qw="7.370829E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_005" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_005" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-71.45493" y="-58.97347" z="77.36266"/>
 					<quaternion qx="3.365064E-07" qy="3.365064E-07" qz="-0.976296" qw="-0.2164396"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_006" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_006" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-71.45493" y="-58.97345" z="-76.77098"/>
 					<quaternion qx="-0.976296" qy="0.2164396" qz="-1.016912E-07" qw="9.263004E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_007" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_007" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="71.72191" y="-58.97347" z="77.36266"/>
 					<quaternion qx="2.901346E-07" qy="5.764328E-09" qz="-0.976296" qw="0.2164396"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_008" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_008" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="71.72193" y="-58.97345" z="-76.77098"/>
 					<quaternion qx="-0.976296" qy="-0.2164396" qz="3.526248E-08" qw="1.590588E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="88.56729" z="-112.4238"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="88.56729" z="-138.5767"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="88.66701" z="106.9478"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="88.66701" z="135.2069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.55728E-07" y="-88.66974" z="111.4439"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.55728E-07" y="-88.66974" z="140.8747"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.55728E-07" y="-88.6509" z="-142.3311"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.55728E-07" y="-88.6509" z="-115.8617"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/assets/structures/defence/defence_tel_tube_01.xml
+++ b/assets/structures/defence/defence_tel_tube_01.xml
@@ -222,12 +222,12 @@
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05 " tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05 " tags="large shield standard">
 				<offset>
 					<position x="0" y="77.91045" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06 " tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06 " tags="large shield standard">
 				<offset>
 					<position x="-8.949707E-07" y="-77.87509" z="0"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>

--- a/assets/units/size_l/ship_arg_l_centaur.xml
+++ b/assets/units/size_l/ship_arg_l_centaur.xml
@@ -630,49 +630,49 @@
 			<position x="-0.0" y="26.0" z="-185.0"/>
 		</offset>
 	</connection>
-	<!-- <connection name="con_shieldgen_m_1" tags="medium shield hittable">
+	<!-- <connection name="con_shieldgen_m_1" tags="medium shield hittable standard">
 		<offset>
 			<position x="-0.0" y="16.0" z="-86.0"/>
 			<quaternion qw="1.7320510330969933e-07" qx="-0.999999999999985" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection> -->
-	<connection group="enginegroup" name="con_shieldgen_m_enginegroup_2" tags="medium shield hittable">
+	<connection group="enginegroup" name="con_shieldgen_m_enginegroup_2" tags="medium shield hittable standard">
 		<offset>
 			<position x="-0.0" y="-14.000000000000002" z="-146.0"/>
 			<quaternion qw="-0.10973389752301974" qx="0.9939610011134277" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_5" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_5" tags="medium shield hittable standard">
 		<offset>
 			<position x="-15.5" y="-6.5" z="-31.0"/>
 			<quaternion qw="-0.02499372385725707" qx="0.9544335742368741" qy="-0.2972730506954018" qz="0.007784565975145422"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_6" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_6" tags="medium shield hittable standard">
 		<offset>
 			<position x="-17.0" y="28.999999999999996" z="-88.0"/>
 			<quaternion qw="-0.016678553441028667" qx="0.999062455205832" qy="-0.02410665701396677" qz="-0.031857582155910794"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_7" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_7" tags="medium shield hittable standard">
 		<offset>
 			<position x="-31.0" y="6.0" z="112.00000000000001"/>
 			<quaternion qw="-0.17075791149372582" qx="0.9590067903278491" qy="-0.19262074408022573" qz="0.11851143707405619"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_2" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_2" tags="medium shield hittable standard">
 		<offset>
 			<position x="31.0" y="6.0" z="112.00000000000001"/>
 			<quaternion qw="-0.16740933143983494" qx="0.9595969013781146" qy="0.19303382757918483" qz="-0.11783821121570845"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_3" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="15.5" y="-6.5" z="-31.0"/>
 			<quaternion qw="-0.029163691157129672" qx="0.9545746825606104" qy="0.2964028352867913" qz="-0.009056145225925051"/>
 		</offset>
 	</connection>
-	<connection name="con_shieldgen_m_4" tags="medium shield hittable">
+	<connection name="con_shieldgen_m_4" tags="medium shield hittable standard">
 		<offset>
 			<position x="17.0" y="28.999999999999996" z="-88.0"/>
 			<quaternion qw="-0.018199321996080677" qx="0.9990359046348677" qy="0.022980202413856475" qz="-0.032679599543025524"/>
@@ -738,97 +738,97 @@
 	</connection>
 
 <!-- turrets -->
-	<connection group="top" name="con_m_turret_top_1" tags="turret medium standard hittable">
+	<connection group="top" name="con_m_turret_top_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-0.0" y="66.0" z="15.0"/>
 			<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection>
-	<connection group="top" name="con_m_turret_top_2" tags="turret medium standard hittable">
+	<connection group="top" name="con_m_turret_top_2" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-0.0" y="66.0" z="75.0"/>
 			<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection>
-	<connection group="top" name="con_shieldgen_m_top_3" tags="medium shield hittable">
+	<connection group="top" name="con_shieldgen_m_top_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="-0.0" y="67.0" z="47.0"/>
 			<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection>
-	<connection group="enginegroup" name="con_m_turret_enginegroup_1" tags="turret medium standard hittable">
+	<connection group="enginegroup" name="con_m_turret_enginegroup_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-0.0" y="83.24289999999999" z="-176.049"/>
 			<quaternion qw="-0.0014743262607874125" qx="-4.299993488323753e-05" qy="0.9995744862987682" qz="-0.029131955884150594"/>
 		</offset>
 	</connection>
-	<connection group="right-side-back" name="con_m_turret_right-side-back_1" tags="turret medium standard hittable">
+	<connection group="right-side-back" name="con_m_turret_right-side-back_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="33.934799999999996" y="43.8428" z="-149.881"/>
 			<quaternion qw="-0.7201124198048751" qx="-0.001298900631108727" qy="0.0012350657710328708" qz="0.6938550931660437"/>
 		</offset>
 	</connection>
-	<connection group="left-side-back" name="con_m_turret_left-side-back_1" tags="turret medium standard hittable">
+	<connection group="left-side-back" name="con_m_turret_left-side-back_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-33.934799999999996" y="43.8428" z="-149.881"/>
 			<quaternion qw="-0.7201124198048751" qx="-0.001298900631108727" qy="-0.0012350657710328708" qz="-0.6938550931660437"/>
 		</offset>
 	</connection>
-	<connection group="right-side-back" name="con_m_turret_right-side-back_2" tags="turret medium standard hittable">
+	<connection group="right-side-back" name="con_m_turret_right-side-back_2" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="26.5914" y="7.767799999999999" z="-31.4491"/>
 			<quaternion qw="-0.5082455075013964" qx="0.05734293363494815" qy="-0.0451490342396395" qz="0.8581141280587413"/>
 		</offset>
 	</connection>
-	<connection group="left-side-back" name="con_m_turret_left-side-back_2" tags="turret medium standard hittable">
+	<connection group="left-side-back" name="con_m_turret_left-side-back_2" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-26.5914" y="7.767799999999999" z="-31.4491"/>
 			<quaternion qw="-0.5082455075013964" qx="0.05734293363494815" qy="0.0451490342396395" qz="-0.8581141280587413"/>
 		</offset>
 	</connection>
-	<connection group="right-side-back" name="con_shieldgen_m_right-side-back_3" tags="medium shield hittable">
+	<connection group="right-side-back" name="con_shieldgen_m_right-side-back_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="20.7166" y="32.8225" z="-61.800399999999996"/>
 			<quaternion qw="-0.7432808348969683" qx="-0.01069765402617497" qy="0.00840305373164804" qz="0.6688411989113597"/>
 		</offset>
 	</connection>
-	<connection group="left-side-back" name="con_shieldgen_m_left-side-back_3" tags="medium shield hittable">
+	<connection group="left-side-back" name="con_shieldgen_m_left-side-back_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="-20.7166" y="32.8225" z="-61.800399999999996"/>
 			<quaternion qw="-0.7432808348969683" qx="-0.01069765402617497" qy="-0.00840305373164804" qz="-0.6688411989113597"/>
 		</offset>
 	</connection>
-	<connection group="right-side-front" name="con_m_turret_right-side-front_1" tags="turret medium standard hittable">
+	<connection group="right-side-front" name="con_m_turret_right-side-front_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="30.3699" y="-6.753099999999999" z="167.3615"/>
 			<quaternion qw="-0.10808377182762069" qx="0.6391337876528195" qy="0.16754471224250267" qz="0.7428019043780464"/>
 		</offset>
 	</connection>
-	<connection group="left-side-front" name="con_m_turret_left-side-front_1" tags="turret medium standard hittable">
+	<connection group="left-side-front" name="con_m_turret_left-side-front_1" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-30.3699" y="-6.753099999999999" z="167.3615"/>
 			<quaternion qw="-0.10808377182762069" qx="0.6391337876528195" qy="-0.16754471224250267" qz="-0.7428019043780464"/>
 		</offset>
 	</connection>
-	<connection group="right-side-front" name="con_m_turret_right-side-front_2" tags="turret medium standard hittable">
+	<connection group="right-side-front" name="con_m_turret_right-side-front_2" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="34.0614" y="22.5131" z="165.2603"/>
 			<quaternion qw="-0.7719813364940177" qx="-0.13576801173483158" qy="-0.6111915592107935" qz="0.10980319232135254"/>
 		</offset>
 	</connection>
-	<connection group="left-side-front" name="con_m_turret_left-side-front_2" tags="turret medium standard hittable">
+	<connection group="left-side-front" name="con_m_turret_left-side-front_2" tags="turret medium standard hittable combat">
 		<offset>
 			<position x="-34.0614" y="22.5131" z="165.2603"/>
 			<quaternion qw="-0.7719813364940177" qx="-0.13576801173483158" qy="0.6111915592107935" qz="-0.10980319232135254"/>
 		</offset>
 	</connection>
-	<connection group="right-side-front" name="con_shieldgen_m_right-side-front_3" tags="medium shield hittable">
+	<connection group="right-side-front" name="con_shieldgen_m_right-side-front_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="44.4825" y="19.1695" z="147.86870000000002"/>
 			<quaternion qw="-0.9591557121559474" qx="-0.004562260855268383" qy="0.010881195812174706" qz="0.2826324560134645"/>
 		</offset>
 	</connection>
-	<connection group="left-side-front" name="con_shieldgen_m_left-side-front_3" tags="medium shield hittable">
+	<connection group="left-side-front" name="con_shieldgen_m_left-side-front_3" tags="medium shield hittable standard">
 		<offset>
 			<position x="-44.4825" y="19.1695" z="147.86870000000002"/>
 			<quaternion qw="-0.9591557121559474" qx="-0.004562260855268383" qy="-0.010881195812174706" qz="-0.2826324560134645"/>

--- a/assets/units/size_l/ship_arg_l_centaur.xml
+++ b/assets/units/size_l/ship_arg_l_centaur.xml
@@ -625,7 +625,7 @@
 			<quaternion qw="-0.14780925325832603" qx="0.9890158869559255" qy="0.0" qz="-0.0"/>
 		</offset>
 	</connection>
-	<connection group="enginegroup" name="con_engine_l_enginegroup_1" tags="engine large">
+	<connection group="enginegroup" name="con_engine_l_enginegroup_1" tags="engine large standard">
 		<offset>
 			<position x="-0.0" y="26.0" z="-185.0"/>
 		</offset>

--- a/assets/units/size_l/ship_arg_l_cyclops.xml
+++ b/assets/units/size_l/ship_arg_l_cyclops.xml
@@ -526,7 +526,7 @@
 
   <!--      ||| ENGINES |||       -->
   
-			<connection name="con_engine_l_1" group="group_back_up_mid " tags="engine large">
+			<connection name="con_engine_l_1" group="group_back_up_mid " tags="engine large standard">
 							<offset>
 					<position x="0" y="0.3" z="-199.5"/>
 					<quaternion qw="0.0" qx="0.0" qy="0.0" qz="0.0"/>

--- a/assets/units/size_l/ship_arg_l_cyclops.xml
+++ b/assets/units/size_l/ship_arg_l_cyclops.xml
@@ -255,7 +255,7 @@
 			
   <!--      ||| COCKPIT/DOCKS ETC |||       -->
 
-			<connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="0" y="-23.8" z="143.7"/>
 				</offset>
@@ -350,37 +350,37 @@
 
   <!--      ||| TURRETS |||       -->
  			
-			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_2" tags="turret medium standard hittable">
+			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-59" y="-26" z="-138"/>
 					<rotation pitch="0" yaw="0" roll="233"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_2" tags="turret medium standard hittable">
+			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="59" y="-26" z="-138"/>
 					<rotation pitch="0" yaw="0" roll="127"/>
 				</offset>
 			</connection>
-			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_1" tags="turret medium standard hittable">
+			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-59" y="-26" z="-108"/>
 					<rotation pitch="0" yaw="0" roll="233"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_1" tags="turret medium standard hittable">
+			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="59" y="-26" z="-108"/>
 					<rotation pitch="0" yaw="0" roll="127"/>
 				</offset>
 			</connection>
-			<connection group="left-bottom-back" name="con_shieldgen_m_left-bottom-back_1" tags="medium shield hittable">
+			<connection group="left-bottom-back" name="con_shieldgen_m_left-bottom-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-59" y="-26" z="-123"/>
 					<rotation pitch="0" yaw="0" roll="233"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_shieldgen_m_right-bottom-back_1" tags="medium shield hittable">
+			<connection group="right-bottom-back" name="con_shieldgen_m_right-bottom-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="59" y="-26" z="-123"/>
 					<rotation pitch="0" yaw="0" roll="127"/>
@@ -389,37 +389,37 @@
 
 			
 			
-			<connection group="left-top-back" name="con_shieldgen_m_left-top-back_1" tags="medium shield hittable">
+			<connection group="left-top-back" name="con_shieldgen_m_left-top-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-59" y="26" z="-123"/>
 					<rotation pitch="0" yaw="0" roll="307"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_shieldgen_m_right-top-back_1" tags="medium shield hittable">
+			<connection group="right-top-back" name="con_shieldgen_m_right-top-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="59" y="26" z="-123"/>
 					<rotation pitch="0" yaw="0" roll="53"/>
 				</offset>
 			</connection>
-			<connection group="left-top-back" name="con_m_turret_left-top-back_1" tags="turret medium standard hittable">
+			<connection group="left-top-back" name="con_m_turret_left-top-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-59" y="26" z="-108"/>
 					<rotation pitch="0" yaw="0" roll="307"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_m_turret_right-top-back_1" tags="turret medium standard hittable">
+			<connection group="right-top-back" name="con_m_turret_right-top-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="59" y="26" z="-108"/>
 					<rotation pitch="0" yaw="0" roll="53"/>
 				</offset>
 			</connection>
-			<connection group="left-top-back" name="con_m_turret_left-top-back_2" tags="turret medium standard hittable">
+			<connection group="left-top-back" name="con_m_turret_left-top-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-59" y="26" z="-138"/>
 					<rotation pitch="0" yaw="0" roll="307"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_m_turret_right-top-back_2" tags="turret medium standard hittable">
+			<connection group="right-top-back" name="con_m_turret_right-top-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="59" y="26" z="-138"/>
 					<rotation pitch="0" yaw="0" roll="53"/>
@@ -428,19 +428,19 @@
 
 			
 			
-			<connection group="left-mid" name="con_shieldgen_m_left-mid_1" tags="medium shield hittable">
+			<connection group="left-mid" name="con_shieldgen_m_left-mid_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-40.745" y="22" z="107.5"/>
 					<rotation pitch="0" yaw="0" roll="305"/>
 				</offset>
 			</connection>
-			<connection group="left-mid" name="con_m_turret_left-mid_1" tags="turret medium standard hittable">
+			<connection group="left-mid" name="con_m_turret_left-mid_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-44.333" y="8" z="100"/>
 					<rotation pitch="0" yaw="0" roll="-90"/>
 				</offset>
 			</connection>
-			<connection group="left-mid" name="con_m_turret_left-mid_2" tags="turret medium standard hittable">
+			<connection group="left-mid" name="con_m_turret_left-mid_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-44.333" y="8" z="115"/>
 					<rotation pitch="0" yaw="0" roll="-90"/>
@@ -449,19 +449,19 @@
 			
 			
 			
-			<connection group="left-mid2" name="con_shieldgen_m_left-mid2_1" tags="medium shield hittable">
+			<connection group="left-mid2" name="con_shieldgen_m_left-mid2_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-40.745" y="-22" z="107.5"/>
 					<rotation pitch="0" yaw="0" roll="235"/>
 				</offset>
 			</connection>
-			<connection group="left-mid2" name="con_m_turret_left-mid2_1" tags="turret medium standard hittable">
+			<connection group="left-mid2" name="con_m_turret_left-mid2_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-44.333" y="-6" z="100"/>
 					<rotation pitch="0" yaw="0" roll="-90"/>
 				</offset>
 			</connection>
-			<connection group="left-mid2" name="con_m_turret_left-mid2_2" tags="turret medium standard hittable">
+			<connection group="left-mid2" name="con_m_turret_left-mid2_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-44.333" y="-6" z="115"/>
 					<rotation pitch="0" yaw="0" roll="-90"/>
@@ -472,19 +472,19 @@
 			
 			
 			
-			<connection group="right-mid" name="con_shieldgen_m_right-mid_1" tags="medium shield hittable">
+			<connection group="right-mid" name="con_shieldgen_m_right-mid_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="40.745" y="22" z="107.5"/>
 					<rotation pitch="0" yaw="0" roll="55"/>
 				</offset>
 			</connection>
-			<connection group="right-mid" name="con_m_turret_right-mid_1" tags="turret medium standard hittable">
+			<connection group="right-mid" name="con_m_turret_right-mid_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="44.333" y="8" z="100"/>
 					<rotation pitch="0" yaw="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection group="right-mid" name="con_m_turret_right-mid_2" tags="turret medium standard hittable">
+			<connection group="right-mid" name="con_m_turret_right-mid_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="44.333" y="8" z="115"/>
 					<rotation pitch="0" yaw="0" roll="90"/>
@@ -492,19 +492,19 @@
 			</connection>
 			
 			
-			<connection group="right-mid2" name="con_shieldgen_m_right-mid2_1" tags="medium shield hittable">
+			<connection group="right-mid2" name="con_shieldgen_m_right-mid2_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="40.745" y="-22" z="107.5"/>
 					<rotation pitch="0" yaw="0" roll="125"/>
 				</offset>
 			</connection>
-			<connection group="right-mid2" name="con_m_turret_right-mid2_1" tags="turret medium standard hittable">
+			<connection group="right-mid2" name="con_m_turret_right-mid2_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="44.333" y="-6" z="100"/>
 					<rotation pitch="0" yaw="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection group="right-mid2" name="con_m_turret_right-mid2_2" tags="turret medium standard hittable">
+			<connection group="right-mid2" name="con_m_turret_right-mid2_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="44.333" y="-6" z="115"/>
 					<rotation pitch="0" yaw="0" roll="90"/>
@@ -515,7 +515,7 @@
 			
   <!--      ||| SHIELDS |||       -->		
   
-			<connection name="con_shieldgen_l_1" tags="large shield hittable">
+			<connection name="con_shieldgen_l_1" tags="large shield hittable standard">
 				<offset>
 					<position x="0" y="-26" z="7"/>
 					<rotation pitch="0" yaw="0" roll="180"/>
@@ -532,13 +532,13 @@
 					<quaternion qw="0.0" qx="0.0" qy="0.0" qz="0.0"/>
 				</offset>
 			</connection>
-			<connection group="group_back_up_mid " name="con_shieldgen_m_group_back_up_mid_1 " tags="medium shield hittable">
+			<connection group="group_back_up_mid " name="con_shieldgen_m_group_back_up_mid_1 " tags="medium shield hittable standard">
 				<offset>
 					<position x="-31.3" y="0.3" z="-209.1"/>
 					<rotation pitch="0" yaw="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection group="group_back_up_mid " name="con_shieldgen_m_group_back_up_mid_2 " tags="medium shield hittable">
+			<connection group="group_back_up_mid " name="con_shieldgen_m_group_back_up_mid_2 " tags="medium shield hittable standard">
 				<offset>
 					<position x="31.3" y="0.3" z="-209.1"/>
 					<rotation pitch="0" yaw="0" roll="-90"/>

--- a/assets/units/size_l/ship_arg_l_destroyer_01.xml
+++ b/assets/units/size_l/ship_arg_l_destroyer_01.xml
@@ -10,14 +10,14 @@
     </add> 
 
 	<add sel="//components/component/connections">
-        <connection group="group_front_down_left" name="con_turret_015" tags="turret medium standard missile hittable">
+        <connection group="group_front_down_left" name="con_turret_015" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="-106.1493" y="27.4886" z="198.2894"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
             </offset>
         </connection>
 
-        <connection group="group_front_down_left" name="con_turret_016" tags="turret medium standard missile hittable">
+        <connection group="group_front_down_left" name="con_turret_016" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="-106.1493" y="25.04860" z="20"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
@@ -25,7 +25,7 @@
         </connection>
 
 
-        <connection group="group_front_down_left" name="con_shieldgen_009" tags="medium shield hittable">
+        <connection group="group_front_down_left" name="con_shieldgen_009" tags="medium shield hittable standard">
             <offset>
                 <position x="-86.5045" y="25.04860" z="99.62886"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
@@ -35,21 +35,21 @@
 
 
 
-        <connection group="group_front_down_right" name="con_turret_017" tags="turret medium standard missile hittable">
+        <connection group="group_front_down_right" name="con_turret_017" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="105.9425" y="27.4886" z="198.2894"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
             </offset>
         </connection>
 
-        <connection group="group_front_down_right" name="con_turret_018" tags="turret medium standard missile hittable">
+        <connection group="group_front_down_right" name="con_turret_018" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="105.9425" y="25.04860" z="20"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
             </offset>
         </connection>
 
-        <connection group="group_front_down_right" name="con_shieldgen_010" tags="medium shield hittable">
+        <connection group="group_front_down_right" name="con_shieldgen_010" tags="medium shield hittable standard">
             <offset>
                 <position x="86.34224" y="25.04860" z="99.62886"/>
                 <quaternion qx="-0" qy="-0" qz="-1" qw="0"/>
@@ -59,25 +59,25 @@
 
 
 
-        <connection group="group_front_up_back_right_tur" name="con_turret_019" tags="turret medium standard missile hittable">
+        <connection group="group_front_up_back_right_tur" name="con_turret_019" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="134" y="76" z="-130"/>
             </offset>
         </connection>
 
-        <connection group="group_front_up_back_right_tur" name="con_shieldgen_011" tags="medium shield hittable">
+        <connection group="group_front_up_back_right_tur" name="con_shieldgen_011" tags="medium shield hittable standard">
             <offset>
                 <position x="134" y="76.2" z="-103.5"/>
             </offset>
         </connection>
 
-        <connection group="group_front_up_back_left_tur" name="con_turret_020" tags="turret medium standard missile hittable">
+        <connection group="group_front_up_back_left_tur" name="con_turret_020" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="-134" y="76" z="-130"/>
             </offset>
         </connection>
 
-        <connection group="group_front_up_back_left_tur" name="con_shieldgen_012" tags="medium shield hittable">
+        <connection group="group_front_up_back_left_tur" name="con_shieldgen_012" tags="medium shield hittable standard">
             <offset>
                 <position x="-134" y="76.2" z="-103.5"/>
             </offset>
@@ -86,7 +86,7 @@
 
 
 
-        <connection name="con_shieldgen_013" group="group_back_up_mid " tags="medium shield hittable ">
+        <connection name="con_shieldgen_013" group="group_back_up_mid " tags="medium shield hittable standard ">
 			<offset>
 					<position x="-11" y="81.58002" z="-260.0025"/>
 			</offset>
@@ -96,7 +96,7 @@
     </add>
 
     <replace sel="//components/component/connections/connection[@name='con_shieldgen_006']">
-    <connection name="con_shieldgen_006" group="group_back_up_mid " tags="medium shield hittable ">
+    <connection name="con_shieldgen_006" group="group_back_up_mid " tags="medium shield hittable standard ">
 			<offset>
 					<position x="11" y="81.58002" z="-260.0025"/>
 			</offset>

--- a/assets/units/size_l/ship_arg_l_trans_container_03.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_03.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<replace sel="//components/component/connections/connection[@name='con_turret_03']">
-		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable ">
+		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable combat">
 				<offset>
 					<position x="2.468497E-06" y="130.828" z="638.5369"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>
@@ -276,7 +276,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-4.183026E-02" y="31.86778" z="-916.635"/>
 				</offset>
@@ -286,7 +286,7 @@
 					<position x="2.662848E-06" y="227.4373" z="60.91885"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-4.183026E-02" y="-56.625" z="-916.6051"/>
 				</offset>
@@ -356,46 +356,46 @@
 					<position x="2.662848E-06" y="103.8971" z="389.8236"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="1.65198E-06" y="103.8901" z="170.9417"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.662848E-06" y="-117.9192" z="170.9419"/>
 					<quaternion qx="-3.139165E-07" qy="5.205486E-07" qz="-1" qw="-6.464356E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.468497E-06" y="130.828" z="638.5369"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_001" group="group_front_mid_right " tags="medium shield hittable ">
+			<connection name="con_shield_m_001" group="group_front_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="-110.4448" z="49.8152"/>
 					<quaternion qx="-1" qy="1.192483E-08" qz="-7.549791E-08" qw="6.278329E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_002" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shield_m_002" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="8.282682E-06" y="96.33418" z="48.48629"/>
 					<quaternion qx="-2.753575E-07" qy="0.7071069" qz="-3.989921E-07" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable ">
+			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="75.77682" z="-734.2194"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-132.2807" y="76.836" z="-861.4772"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-18.5735" y="-127.4435" z="638.5166"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.4999999" qw="-0.5"/>
@@ -406,23 +406,23 @@
 					<position x="2.662848E-06" y="103.9134" z="-496.0661"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_mid_top " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_mid_top " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="131.5233" y="76.8254" z="-861.4778"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.773571E-05" y="103.9046" z="-32.23453"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.662848E-06" y="-117.9229" z="-32.23415"/>
 					<quaternion qx="-3.139165E-07" qy="5.205486E-07" qz="-1" qw="-6.464356E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_005" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_005" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="71.18539" z="-863.2751"/>
 				</offset>

--- a/assets/units/size_l/ship_arg_l_trans_container_03.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_03.xml
@@ -351,7 +351,7 @@
 					<position x="2.662848E-06" y="229.3213" z="90.99336"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_01" tags="large shield ">
+			<connection name="con_shield_l_01" tags="large shield standard">
 				<offset>
 					<position x="2.662848E-06" y="103.8971" z="389.8236"/>
 				</offset>
@@ -401,7 +401,7 @@
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.4999999" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_02" tags="large shield ">
+			<connection name="con_shield_l_02" tags="large shield standard">
 				<offset>
 					<position x="2.662848E-06" y="103.9134" z="-496.0661"/>
 				</offset>

--- a/assets/units/size_l/ship_arg_l_trans_container_03p.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_03p.xml
@@ -332,7 +332,7 @@
 					<position x="2.662848E-06" y="229.3213" z="90.99336"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_01" tags="large shield ">
+			<connection name="con_shield_l_01" tags="large shield standard">
 				<offset>
 					<position x="2.662848E-06" y="103.8971" z="389.8236"/>
 				</offset>
@@ -382,7 +382,7 @@
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.4999999" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_02" tags="large shield ">
+			<connection name="con_shield_l_02" tags="large shield standard">
 				<offset>
 					<position x="2.662848E-06" y="103.9134" z="-496.0661"/>
 				</offset>

--- a/assets/units/size_l/ship_arg_l_trans_container_03p.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_03p.xml
@@ -257,7 +257,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-4.183026E-02" y="31.86778" z="-916.635"/>
 				</offset>
@@ -267,7 +267,7 @@
 					<position x="2.662848E-06" y="227.4373" z="60.91885"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-4.183026E-02" y="-56.625" z="-916.6051"/>
 				</offset>
@@ -337,46 +337,46 @@
 					<position x="2.662848E-06" y="103.8971" z="389.8236"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="1.65198E-06" y="103.8901" z="170.9417"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.662848E-06" y="-117.9192" z="170.9419"/>
 					<quaternion qx="-3.139165E-07" qy="5.205486E-07" qz="-1" qw="-6.464356E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable ">
+			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable combat">
 				<offset>
 					<position x="2.468497E-06" y="130.828" z="638.5369"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_001" group="group_front_mid_right " tags="medium shield hittable ">
+			<connection name="con_shield_m_001" group="group_front_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="-110.4448" z="49.8152"/>
 					<quaternion qx="-1" qy="1.192483E-08" qz="-7.549791E-08" qw="6.278329E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_002" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shield_m_002" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="8.282682E-06" y="96.33418" z="48.48629"/>
 					<quaternion qx="-2.753575E-07" qy="0.7071069" qz="-3.989921E-07" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable ">
+			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="75.77682" z="-734.2194"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-132.2807" y="76.836" z="-861.4772"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-18.5735" y="-127.4435" z="638.5166"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.4999999" qw="-0.5"/>
@@ -387,23 +387,23 @@
 					<position x="2.662848E-06" y="103.9134" z="-496.0661"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_mid_top " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_mid_top " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="131.5233" y="76.8254" z="-861.4778"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.773571E-05" y="103.9046" z="-32.23453"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="2.662848E-06" y="-117.9229" z="-32.23415"/>
 					<quaternion qx="-3.139165E-07" qy="5.205486E-07" qz="-1" qw="-6.464356E-14"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_005" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_005" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="71.18539" z="-863.2751"/>
 				</offset>
@@ -420,13 +420,13 @@
  				 </offset>
  			</connection>
 <!-- new turrets -->
-			<connection name="con_turret_08" group="group_top_l_frw" tags="turret large standard hittable ">
+			<connection name="con_turret_08" group="group_top_l_frw" tags="turret large standard hittable combat">
 				<offset>
 					<position x="0" y="100" z="-187"/>
 					<rotation yaw="0" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_006" group="group_top_l_frw" tags="medium shield hittable ">
+			<connection name="con_shield_m_006" group="group_top_l_frw" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="101" z="-98"/>
 					<rotation yaw="0" pitch="0" roll="0"/>
@@ -434,13 +434,13 @@
 			</connection>
 
 
-			<connection name="con_turret_09" group="group_top_l_rear" tags="turret large standard hittable ">
+			<connection name="con_turret_09" group="group_top_l_rear" tags="turret large standard hittable combat">
 				<offset>
 					<position x="0" y="100" z="-341"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_007" group="group_top_l_rear" tags="medium shield hittable ">
+			<connection name="con_shield_m_007" group="group_top_l_rear" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="101" z="-429"/>
 					<rotation yaw="180" pitch="0" roll="0"/>

--- a/assets/units/size_l/ship_arg_l_trans_container_04.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_04.xml
@@ -2,7 +2,7 @@
 
 <diff>
 	<replace sel="//components/component/connections/connection[@name='con_turret_03']">
-		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable ">
+		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable combat">
 				<offset>
 					<position x="-1.200639E-05" y="-216.2524" z="628.2923"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>
@@ -225,7 +225,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-110.1499" y="58.82938" z="-1005.105"/>
 				</offset>
@@ -235,7 +235,7 @@
 					<position x="2.662848E-06" y="182.6133" z="-205.3253"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-95.34542" y="-25.12098" z="-1005.075"/>
 				</offset>
@@ -300,34 +300,34 @@
 					<position x="2.662848E-06" y="107.0671" z="66.88651"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_mid_up " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_front_mid_up " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="7.240116E-06" y="104.704" z="201.6103"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_front_mid_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.200639E-05" y="-216.2524" z="628.2923"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_002" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shield_m_002" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="1.387082E-05" y="100.2477" z="171.3656"/>
 					<quaternion qx="-2.753575E-07" qy="0.7071069" qz="-3.989921E-07" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable ">
+			<connection name="con_shield_m_003" group="group_back_mid_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="104.7137" z="-697.4711"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_back_mid_top " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="107.063" z="-774.6059"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_004" group="group_front_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-18.57352" y="-216.379" z="460.7645"/>
 					<quaternion qx="0.5" qy="0.5" qz="-0.5" qw="-0.5"/>
@@ -338,64 +338,64 @@
 					<position x="3.658261E-08" y="107.0613" z="-556.148"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_mid_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_mid_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.090596E-07" y="31.00079" z="-1029.38"/>
 					<quaternion qx="0.7071068" qy="-1.067702E-07" qz="-1.685874E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_front_mid_up " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_front_mid_up " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.214758E-05" y="104.7186" z="142.2531"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-114.6499" y="-3.869127" z="-218.1576"/>
 					<quaternion qx="-1.067702E-07" qy="-1.067702E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_005" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shield_m_005" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-110.1936" y="-3.869112" z="-248.4023"/>
 					<quaternion qx="-0.5000002" qy="0.4999998" qz="-0.5000004" qw="-0.4999997"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-114.6645" y="-3.869142" z="-277.5148"/>
 					<quaternion qx="1.685874E-07" qy="1.685874E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_006" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shield_m_006" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="110.17" y="-3.869142" z="-248.3834"/>
 					<quaternion qx="0.4999997" qy="0.5000006" qz="0.4999996" qw="-0.5000001"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="114.6409" y="-3.869112" z="-277.4959"/>
 					<quaternion qx="-4.439449E-07" qy="4.439449E-07" qz="0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="114.6264" y="-3.869127" z="-218.1387"/>
 					<quaternion qx="-1.067701E-07" qy="1.067702E-07" qz="0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="95.34501" y="-25.12098" z="-1005.075"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="110.15" y="58.82938" z="-1005.105"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_007" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shield_m_007" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.662848E-06" y="96.08882" z="-1021.663"/>
 					<quaternion qx="0.7071067" qy="-5.45103E-07" qz="1.46111E-07" qw="-0.7071068"/>

--- a/assets/units/size_l/ship_arg_l_trans_container_04.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_04.xml
@@ -295,7 +295,7 @@
 					<position x="2.662848E-06" y="184.4974" z="-175.2508"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_01" tags="large shield ">
+			<connection name="con_shield_l_01" tags="large shield standard">
 				<offset>
 					<position x="2.662848E-06" y="107.0671" z="66.88651"/>
 				</offset>
@@ -333,7 +333,7 @@
 					<quaternion qx="0.5" qy="0.5" qz="-0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_l_02" tags="large shield ">
+			<connection name="con_shield_l_02" tags="large shield standard">
 				<offset>
 					<position x="3.658261E-08" y="107.0613" z="-556.148"/>
 				</offset>

--- a/assets/units/size_l/ship_arg_l_trans_container_05.xml
+++ b/assets/units/size_l/ship_arg_l_trans_container_05.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='con_turret_03']">
-		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable ">
+		<connection name="con_turret_03" group="group_front_mid_mid " tags="turret large standard hittable combat">
 				<offset>
 					<position x="-1.641386E-05" y="-216.2525" z="527.4611"/>
 					<quaternion qx="-0.5000001" qy="-0.5" qz="-0.5" qw="-0.5"/>

--- a/assets/units/size_l/ship_par_l_destroyer_01.xml
+++ b/assets/units/size_l/ship_par_l_destroyer_01.xml
@@ -11,7 +11,7 @@
 <remove sel="//components/component/connections/connection[@name='con_turret_laser_l_04']"/>
 <remove sel="//components/component/connections/connection[@name='con_shieldgen_015']"/>
 <replace sel="//components/component/connections/connection[@name='con_shieldgen_008']">
-      <connection name="con_shieldgen_008" group="group_rear_down_mid" tags="medium shield hittable ">
+      <connection name="con_shieldgen_008" group="group_rear_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-7.275229" z="-55.61757"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="1.629207E-07"/>
@@ -19,7 +19,7 @@
 			</connection>
 </replace>
 <add sel="//components/component/connections">
-        <connection group="group_rear_down_mid" name="con_turret_013" tags="turret medium standard missile hittable">
+        <connection group="group_rear_down_mid" name="con_turret_013" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="20" y="-6.897476" z="-85.76994"/>
 					      <quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
@@ -27,7 +27,7 @@
         </connection>
 </add>
 <add sel="//components/component/connections">
-        <connection group="group_rear_down_mid" name="con_turret_014" tags="turret medium standard missile hittable">
+        <connection group="group_rear_down_mid" name="con_turret_014" tags="turret medium standard missile hittable combat">
             <offset>
                 <position x="-20" y="-6.897476" z="-85.76994"/>
 					      <quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>

--- a/assets/units/size_l/ship_par_l_hyperion.xml
+++ b/assets/units/size_l/ship_par_l_hyperion.xml
@@ -205,13 +205,13 @@
 					<position x="-0.0" y="0.0" z="-238.96120000000002"/>
 				</offset>
 			</connection>
-			<connection group="engine-group" name="con_shieldgen_m_engine_1" tags="medium shield hittable">
+			<connection group="engine-group" name="con_shieldgen_m_engine_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="57.6981" y="-4.9376999999999995" z="-231.549"/>
 					<quaternion qw="-0.9910941138190952" qx="-0.0" qy="0.0" qz="0.1331632740403393"/>
 				</offset>
 			</connection>
-			<connection group="engine-group" name="con_shieldgen_m_engine_2" tags="medium shield hittable">
+			<connection group="engine-group" name="con_shieldgen_m_engine_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-57.6981" y="-4.9376999999999995" z="-231.549"/>
 					<quaternion qw="-0.9910940472373342" qx="-0.0" qy="0.0" qz="-0.13316376958737955"/>
@@ -236,97 +236,97 @@
 					<quaternion qw="-0.7976250370991931" qx="-0.09121008014529267" qy="-0.10505124690128172" qz="0.5868894759636485"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable">
+			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-39.5587" y="15.7451" z="4.4937"/>
 					<quaternion qw="-0.06807613527934915" qx="0.6624554198914099" qy="-0.06651930533593554" qz="-0.7430300387464482"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable">
+			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="39.5587" y="15.7451" z="4.4937"/>
 					<quaternion qw="-0.06807613527934915" qx="0.6624554198914099" qy="0.06651930533593554" qz="0.7430300387464482"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-34.422999999999995" y="-21.6999" z="8.0113"/>
 					<quaternion qw="-0.13422993785189533" qx="-0.05223990470883068" qy="-0.018195821656459" qz="-0.9894049869565722"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="34.422999999999995" y="-21.6999" z="8.0113"/>
 					<quaternion qw="-0.13422993785189533" qx="-0.05223990470883068" qy="0.018195821656459" qz="0.9894049869565722"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-34.422999999999995" y="21.6999" z="8.0113"/>
 					<quaternion qw="-0.9892498474293269" qx="-0.017807491345612932" qy="-0.05509964482381813" qz="-0.1342820231949108"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="34.422999999999995" y="21.6999" z="8.0113"/>
 					<quaternion qw="-0.9892498474293269" qx="-0.017807491345612932" qy="0.05509964482381813" qz="0.1342820231949108"/>
 				</offset>
 			</connection>
-			<connection group="left-back" name="con_shieldgen_m_left-back_2" tags="medium shield hittable">
+			<connection group="left-back" name="con_shieldgen_m_left-back_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-57.23740000000001" y="-17.1691" z="-198.07809999999998"/>
 					<quaternion qw="-0.05005540053129854" qx="0.00011984958693438418" qy="-0.0023959929921298973" qz="-0.9987435615468615"/>
 				</offset>
 			</connection>
-			<connection group="right-back" name="con_shieldgen_m_right-back_2" tags="medium shield hittable">
+			<connection group="right-back" name="con_shieldgen_m_right-back_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="57.23740000000001" y="-17.1691" z="-198.07809999999998"/>
 					<quaternion qw="-0.05005540053129854" qx="0.00011984958693438418" qy="0.0023959929921298973" qz="0.9987435615468615"/>
 				</offset>
 			</connection>
-			<connection group="left-back" name="con_shieldgen_m_left-back_1" tags="medium shield hittable">
+			<connection group="left-back" name="con_shieldgen_m_left-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-56.71509999999999" y="17.221700000000002" z="-198.0782"/>
 					<quaternion qw="-0.9987440803509827" qx="-0.0023834267531849316" qy="-0.00011944439636738511" qz="-0.050045648899961465"/>
 				</offset>
 			</connection>
-			<connection group="right-back" name="con_shieldgen_m_right-back_1" tags="medium shield hittable">
+			<connection group="right-back" name="con_shieldgen_m_right-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="56.71509999999999" y="17.221700000000002" z="-198.0782"/>
 					<quaternion qw="-0.9987440803509827" qx="-0.0023834267531849316" qy="0.00011944439636738511" qz="0.050045648899961465"/>
 				</offset>
 			</connection>
-			<connection group="left-back" name="con_m_turret_left-back_2" tags="turret medium standard hittable">
+			<connection group="left-back" name="con_m_turret_left-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-18.9307" y="-22.623199999999997" z="-225.4406"/>
 					<quaternion qw="-0.019409607882003035" qx="-0.9981137746952415" qy="0.058175029294158805" qz="-0.002797472449817075"/>
 				</offset>
 			</connection>
-			<connection group="right-back" name="con_m_turret_right-back_2" tags="turret medium standard hittable">
+			<connection group="right-back" name="con_m_turret_right-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="18.9307" y="-22.623199999999997" z="-225.4406"/>
 					<quaternion qw="-0.019409607882003035" qx="-0.9981137746952415" qy="-0.058175029294158805" qz="0.002797472449817075"/>
 				</offset>
 			</connection>
-			<connection group="left-back" name="con_m_turret_left-back_1" tags="turret medium standard hittable">
+			<connection group="left-back" name="con_m_turret_left-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-19.2352" y="22.5914" z="-225.53580000000002"/>
 					<quaternion qw="0.0005386731790522792" qx="-0.058217975331359605" qy="0.998117577068707" qz="0.01927899183093342"/>
 				</offset>
 			</connection>
-			<connection group="right-back" name="con_m_turret_right-back_1" tags="turret medium standard hittable">
+			<connection group="right-back" name="con_m_turret_right-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="19.2352" y="22.5914" z="-225.53580000000002"/>
 					<quaternion qw="0.0005386731790522792" qx="-0.058217975331359605" qy="-0.998117577068707" qz="-0.01927899183093342"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_2" tags="large shield hittable">
+			<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 				<offset>
 					<position x="0.129" y="18.757199999999997" z="-76.255"/>
 					<quaternion qw="-0.9945219220355069" qx="0.10452820954556248" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_1" tags="large shield hittable">
+			<connection name="con_shieldgen_l_1" tags="large shield hittable standard">
 				<offset>
 					<position x="0.4197" y="-18.1192" z="-76.255"/>
 					<quaternion qw="-0.09584547175399909" qx="0.9953962254018514" qy="0.0" qz="-0.0"/>

--- a/assets/units/size_l/ship_par_l_hyperion.xml
+++ b/assets/units/size_l/ship_par_l_hyperion.xml
@@ -200,7 +200,7 @@
 			</connection>
 
 
-			<connection group="engine-group" name="con_engine_l_1" tags="engine large">
+			<connection group="engine-group" name="con_engine_l_1" tags="engine large standard">
 				<offset>
 					<position x="-0.0" y="0.0" z="-238.96120000000002"/>
 				</offset>

--- a/assets/units/size_l/ship_sca_l_hound.xml
+++ b/assets/units/size_l/ship_sca_l_hound.xml
@@ -933,12 +933,12 @@
 					<quaternion qw="-1.0" qx="-0.0" qy="-0.0" qz="0.0"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_l_2" group="enginegroup" tags="engine large">
+			<connection name="con_engine_l_2" group="enginegroup" tags="engine large standard">
 				<offset>
 					<position x="-140.264" y="-9.523299999999999" z="-146.3665"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_l_1" group="enginegroup" tags="engine large">
+			<connection name="con_engine_l_1" group="enginegroup" tags="engine large standard">
 				<offset>
 					<position x="140.2639" y="-9.523299999999999" z="-146.3665"/>
 				</offset>

--- a/assets/units/size_l/ship_sca_l_hound.xml
+++ b/assets/units/size_l/ship_sca_l_hound.xml
@@ -636,12 +636,12 @@
 			</connection>
 
 <!-- 
-			<connection name="con_weapon_02" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_02" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="-122.9944" y="48.5061" z="227.3688"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="122.9944" y="48.5061" z="227.3629"/>
 				</offset>
@@ -693,49 +693,49 @@
 			</connection>
 
 			<!-- new connection -->
-			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_2" tags="turret medium standard hittable">
+			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-206.49030000000002" y="-56.8788" z="-113.55869999999999"/>
 					<quaternion qw="6.732051033795384e-07" qx="0.0" qy="9.999999999992734e-07" qz="-0.9999999999992734"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_2" tags="turret medium standard hittable">
+			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="206.49030000000002" y="-56.8788" z="-113.55869999999999"/>
 					<quaternion qw="6.732051033795384e-07" qx="0.0" qy="-9.999999999992734e-07" qz="0.9999999999992734"/>
 				</offset>
 			</connection>
-			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_1" tags="turret medium standard hittable">
+			<connection group="left-bottom-back" name="con_m_turret_left-bottom-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-206.49030000000002" y="-56.842000000000006" z="-56.3258"/>
 					<quaternion qw="1.7320510330969933e-07" qx="0.0" qy="9.99999999999485e-07" qz="-0.999999999999485"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_1" tags="turret medium standard hittable">
+			<connection group="right-bottom-back" name="con_m_turret_right-bottom-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="206.49030000000002" y="-56.842000000000006" z="-56.3258"/>
 					<quaternion qw="1.7320510330969933e-07" qx="0.0" qy="-9.99999999999485e-07" qz="0.999999999999485"/>
 				</offset>
 			</connection>
-			<connection group="left-bottom-back" name="con_shieldgen_m_left-bottom-back_1" tags="medium shield hittable">
+			<connection group="left-bottom-back" name="con_shieldgen_m_left-bottom-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-206.48590000000002" y="-52.0764" z="-84.9328"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.7071067811865097" qy="0.0" qz="0.7071067811865097"/>
 				</offset>
 			</connection>
-			<connection group="right-bottom-back" name="con_shieldgen_m_right-bottom-back_1" tags="medium shield hittable">
+			<connection group="right-bottom-back" name="con_shieldgen_m_right-bottom-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="206.48590000000002" y="-52.0764" z="-84.9328"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.7071067811865097" qy="-0.0" qz="-0.7071067811865097"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_2" tags="large shield hittable">
+			<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 				<offset>
 					<position x="-180.05599999999998" y="-52.334" z="101.8204"/>
 					<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="0.0" qz="-0.7071067811865369"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_1" tags="large shield hittable">
+			<connection name="con_shieldgen_l_1" tags="large shield hittable standard">
 				<offset>
 					<position x="180.0559" y="-52.334" z="101.8204"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.7071067811865097" qy="0.0" qz="0.7071067811865097"/>
@@ -783,151 +783,151 @@
 					<quaternion qw="-1" qx="0" qy="0" qz="0"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable">
+			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-155.6632" y="-10.5223" z="344.2407"/>
 					<quaternion qw="-0.6500599492397442" qx="-0.5959876737716076" qy="0.34237670608480564" qz="-0.3240354089250863"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable">
+			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="155.6632" y="-10.5223" z="344.2407"/>
 					<quaternion qw="-0.6500599492397442" qx="-0.5959876737716076" qy="-0.34237670608480564" qz="0.3240354089250863"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-181.1996" y="-10.5223" z="295.81059999999997"/>
 					<quaternion qw="-0.6982112618472857" qx="-0.11180795919533401" qy="-0.11180795919533401" qz="-0.6982112820277042"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="181.1996" y="-10.5223" z="295.81059999999997"/>
 					<quaternion qw="-0.6982112618472857" qx="-0.11180795919533401" qy="0.11180795919533401" qz="0.6982112820277042"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-108.8188" y="-10.5223" z="394.11879999999996"/>
 					<quaternion qw="-0.6221741939150662" qx="-0.33600517211907927" qy="-0.33600517211907927" qz="-0.6221738672144574"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="108.8188" y="-10.5223" z="394.11879999999996"/>
 					<quaternion qw="-0.6221741939150662" qx="-0.33600517211907927" qy="0.33600517211907927" qz="0.6221738672144574"/>
 				</offset>
 			</connection>
-			<connection group="left-top-back" name="con_shieldgen_m_left-top-back_1" tags="medium shield hittable">
+			<connection group="left-top-back" name="con_shieldgen_m_left-top-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-206.48590000000002" y="33.124900000000004" z="-84.5329"/>
 					<quaternion qw="-0.7071068967259818" qx="8.555990529061585e-05" qy="0.7071066552943458" qz="-8.555990529061585e-05"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_shieldgen_m_right-top-back_1" tags="medium shield hittable">
+			<connection group="right-top-back" name="con_shieldgen_m_right-top-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="206.48590000000002" y="33.124900000000004" z="-84.5329"/>
 					<quaternion qw="-0.7071068967259818" qx="8.555990529061585e-05" qy="-0.7071066552943458" qz="8.555990529061585e-05"/>
 				</offset>
 			</connection>
-			<connection group="left-top-back" name="con_m_turret_left-top-back_1" tags="turret medium standard hittable">
+			<connection group="left-top-back" name="con_m_turret_left-top-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-206.49030000000002" y="35.5226" z="-56.3258"/>
 					<quaternion qw="-1.0" qx="0.0" qy="0.0" qz="0.0"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_m_turret_right-top-back_1" tags="turret medium standard hittable">
+			<connection group="right-top-back" name="con_m_turret_right-top-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="206.49030000000002" y="35.5226" z="-56.3258"/>
 					<quaternion qw="-1.0" qx="0.0" qy="-0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="left-top-back" name="con_m_turret_left-top-back_2" tags="turret medium standard hittable">
+			<connection group="left-top-back" name="con_m_turret_left-top-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-206.49030000000002" y="35.5226" z="-119.9945"/>
 					<quaternion qw="-1.0" qx="0.0" qy="0.0" qz="0.0"/>
 				</offset>
 			</connection>
-			<connection group="right-top-back" name="con_m_turret_right-top-back_2" tags="turret medium standard hittable">
+			<connection group="right-top-back" name="con_m_turret_right-top-back_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="206.49030000000002" y="35.5226" z="-119.9945"/>
 					<quaternion qw="-1.0" qx="0.0" qy="-0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="left-mid" name="con_shieldgen_m_left-mid_1" tags="medium shield hittable">
+			<connection group="left-mid" name="con_shieldgen_m_left-mid_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-264.383" y="-7.391399999999999" z="152.701"/>
 					<quaternion qw="-0.7071284631503876" qx="-1.5555872160743758e-05" qy="1.5555872160743758e-05" qz="-0.7070850982156255"/>
 				</offset>
 			</connection>
-			<connection group="right-mid" name="con_shieldgen_m_right-mid_1" tags="medium shield hittable">
+			<connection group="right-mid" name="con_shieldgen_m_right-mid_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="264.383" y="-7.391399999999999" z="152.701"/>
 					<quaternion qw="-0.7071284631503876" qx="-1.5555872160743758e-05" qy="-1.5555872160743758e-05" qz="0.7070850982156255"/>
 				</offset>
 			</connection>
-			<connection group="left-mid" name="con_m_turret_left-mid_2" tags="turret medium standard hittable">
+			<connection group="left-mid" name="con_m_turret_left-mid_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-265.9927" y="-7.2911" z="108.04750000000001"/>
 					<quaternion qw="-0.707104421848321" qx="-0.0" qy="0.0" qz="-0.7071091405169019"/>
 				</offset>
 			</connection>
-			<connection group="right-mid" name="con_m_turret_right-mid_2" tags="turret medium standard hittable">
+			<connection group="right-mid" name="con_m_turret_right-mid_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="265.9927" y="-7.2911" z="108.04750000000001"/>
 					<quaternion qw="-0.707104421848321" qx="-0.0" qy="-0.0" qz="0.7071091405169019"/>
 				</offset>
 			</connection>
-			<connection group="left-mid" name="con_m_turret_left-mid_1" tags="turret medium standard hittable">
+			<connection group="left-mid" name="con_m_turret_left-mid_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-265.9927" y="-7.5064" z="196.6905"/>
 					<quaternion qw="-0.707104421848321" qx="-0.0" qy="0.0" qz="-0.7071091405169019"/>
 				</offset>
 			</connection>
-			<connection group="right-mid" name="con_m_turret_right-mid_1" tags="turret medium standard hittable">
+			<connection group="right-mid" name="con_m_turret_right-mid_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="265.9927" y="-7.5064" z="196.6905"/>
 					<quaternion qw="-0.707104421848321" qx="-0.0" qy="-0.0" qz="0.7071091405169019"/>
 				</offset>
 			</connection>
-			<connection group="left-l-tur" name="con_shieldgen_m_left-l-tur_1" tags="medium shield hittable">
+			<connection group="left-l-tur" name="con_shieldgen_m_left-l-tur_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-126.95669999999998" y="30.2704" z="152.701"/>
 					<quaternion qw="-0.9807864588965824" qx="-2.789706851952059e-05" qy="-3.901687904828054e-07" qz="0.19508439524140272"/>
 				</offset>
 			</connection>
-			<connection group="right-l-tur" name="con_shieldgen_m_right-l-tur_1" tags="medium shield hittable">
+			<connection group="right-l-tur" name="con_shieldgen_m_right-l-tur_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="126.95669999999998" y="30.2704" z="152.701"/>
 					<quaternion qw="-0.9807864588965824" qx="-2.789706851952059e-05" qy="3.901687904828054e-07" qz="-0.19508439524140272"/>
 				</offset>
 			</connection>
-			<connection group="bottom-l-tur" name="con_shieldgen_m_bottom-l-tur_2" tags="medium shield hittable">
+			<connection group="bottom-l-tur" name="con_shieldgen_m_bottom-l-tur_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="41.5355" y="-99.2803" z="-0.5575"/>
 					<quaternion qw="1.7320510330969933e-07" qx="-0.999999999999985" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="bottom-l-tur" name="con_shieldgen_m_bottom-l-tur_1" tags="medium shield hittable">
+			<connection group="bottom-l-tur" name="con_shieldgen_m_bottom-l-tur_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-41.5355" y="-99.2803" z="-0.5575"/>
 					<quaternion qw="1.7320510330969933e-07" qx="-0.999999999999985" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="bottom-l-tur" name="con_l_turret_bottom-l-tur_1" tags="turret large standard hittable">
+			<connection group="bottom-l-tur" name="con_l_turret_bottom-l-tur_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-0.0" y="-99.2803" z="-0.5575"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.9999999999999466" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="left-l-tur" name="con_l_turret_left-l-tur_1" tags="turret large standard hittable">
+			<connection group="left-l-tur" name="con_l_turret_left-l-tur_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-192.8693" y="33.124900000000004" z="152.7005"/>
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="right-l-tur" name="con_l_turret_right-l-tur_1" tags="turret large standard hittable">
+			<connection group="right-l-tur" name="con_l_turret_right-l-tur_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="192.8693" y="33.124900000000004" z="152.7005"/>
 					<quaternion qw="-1.0" qx="-0.0" qy="-0.0" qz="0.0"/>
@@ -943,13 +943,13 @@
 					<position x="140.2639" y="-9.523299999999999" z="-146.3665"/>
 				</offset>
 			</connection>
-			<connection group="enginegroup" name="con_shieldgen_m_enginegroup_1" tags="medium shield hittable">
+			<connection group="enginegroup" name="con_shieldgen_m_enginegroup_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-192.844" y="-40.076299999999996" z="-118.085"/>
 					<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="enginegroup" name="con_shieldgen_m_enginegroup_2" tags="medium shield hittable">
+			<connection group="enginegroup" name="con_shieldgen_m_enginegroup_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="192.8439" y="-40.076299999999996" z="-118.085"/>
 					<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>

--- a/assets/units/size_l/ship_sdp_frigate_triton.xml
+++ b/assets/units/size_l/ship_sdp_frigate_triton.xml
@@ -294,12 +294,12 @@
 
 
 			<!-- engine !-->
-			<connection name="con_engine_01" group="group_engine" tags="engine large ">
+			<connection name="con_engine_01" group="group_engine" tags="engine large standard ">
 				<offset>
 					<position x="0" y="0" z="-130.572"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_engine" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_engine" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="30.4724" z="-139.314"/>
 					<quaternion qx="0.691859" qy="0.129331" qz="-0.698715" qw="-0.128063"/>
@@ -324,26 +324,26 @@
 
 
 			<!-- mid turrets !-->
-			<connection name="con_turret_02" group="group_mid_turret" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_turret" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="49.4505" y="8.64263" z="-55.6606"/>
 					<quaternion qx="75.33772e-08" qy="0.707002" qz="-5.3393e-08" qw="0.707211"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_mid_turret" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_mid_turret" tags="medium shield hittable standard ">
 				<offset>
 					<position x="63.1725" y="5.96449" z="-55.7154"/>
 					<quaternion qx="-0.0" qy="3.47464e-08" qz="-0.291474" qw="0.956579"/>
 				</offset>
 			</connection>
 
-			<connection name="con_turret_03" group="group_mid_turret" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_mid_turret" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-49.4505" y="8.64263" z="-55.6606"/>
 					<quaternion qx="75.33772e-08" qy="-0.707002" qz="5.3393e-08" qw="0.707211"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_mid_turret" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_mid_turret" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-63.1725" y="5.96449" z="-55.7154"/>
 					<quaternion qx="0.0" qy="-3.47464e-08" qz="0.291474" qw="0.956579"/>
@@ -352,38 +352,38 @@
 
 
 			<!-- main turrets !-->
-			<connection name="con_turret_l_01" group="group_turret_l_up" tags="turret large missile standard ">
+			<connection name="con_turret_l_01" group="group_turret_l_up" tags="turret large missile standard combat">
 				<offset>
 					<position x="0" y="26.013" z="-50.9138"/>
 					<quaternion qx="0" qy="1" qz="0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_turret_l_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_turret_l_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-6.34389" y="27.875" z="-102.762"/>
 				  <rotation pitch="-5.76975" yaw="-5.9874" roll="0.603823"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_turret_l_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_turret_l_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="6.34389" y="27.875" z="-102.762"/>
 				  <rotation pitch="-5.76975" yaw="5.9874" roll="0.603823"/>
 				</offset>
 			</connection>
 
-			<connection name="con_turret_l_02" group="group_turret_l_down" tags="turret large missile standard ">
+			<connection name="con_turret_l_02" group="group_turret_l_down" tags="turret large missile standard combat">
 				<offset>
 					<position x="0" y="-20.0537" z="-53.0054"/>
 					<quaternion qx="0" qy="0" qz="1.0" qw="7.54979e-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_turret_l_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_turret_l_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="8.72488" y="-19.3264" z="-16.4918"/>
 					<quaternion qx="0.701883" qy="-0.080077" qz="-0.70325" qw="0.079921"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_turret_l_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_turret_l_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-8.72488" y="-19.3264" z="-16.4918"/>
 					<quaternion qx="0.701883" qy="-0.080077" qz="-0.70325" qw="0.079921"/>

--- a/assets/units/size_l/ship_sdp_frigate_triton.xml
+++ b/assets/units/size_l/ship_sdp_frigate_triton.xml
@@ -308,7 +308,7 @@
 
 
 			<!-- Main shield !-->
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="0" y="-17.45" z="22.1149"/>
 					<quaternion qx="-1" qy="0" qz="1.48028e-14" qw="0"/>

--- a/assets/units/size_l/ship_spl_l_panther.xml
+++ b/assets/units/size_l/ship_spl_l_panther.xml
@@ -227,13 +227,13 @@
 			</connection>
 
 
-			<connection group="top" name="con_shieldgen_m_top_1" tags="medium shield hittable">
+			<connection group="top" name="con_shieldgen_m_top_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-1.6214" y="71.06479999999999" z="-79.9426"/>
 					<quaternion qw="-0.7071401299582554" qx="0.006859315553861948" qy="-0.7070398068272258" qz="0.0007056588931815508"/>
 				</offset>
 			</connection>
-			<connection group="top" name="con_m_turret_top_1" tags="turret medium standard hittable">
+			<connection group="top" name="con_m_turret_top_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-1.8492000000000002" y="71.49170000000001" z="-62.639599999999994"/>
 					<quaternion qw="-0.9997572942901874" qx="-0.020781156308275865" qy="0.0010041504781469262" qz="-0.007244842156450359"/>
@@ -244,26 +244,26 @@
 					<position x="-1.5667" y="-47.7941" z="-223.2353"/>
 				</offset>
 			</connection>
-			<connection group="enggroup" name="con_shieldgen_m_enggroup_1" tags="medium shield hittable">
+			<connection group="enggroup" name="con_shieldgen_m_enggroup_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-1.1151" y="-86.8796" z="-163.32670000000002"/>
 					<quaternion qw="0.0022156713922372234" qx="-0.0005249984641955111" qy="-0.0008159976129210229" qz="-0.9999970746581163"/>
 				</offset>
 			</connection>
 		
-			<connection name="con_shieldgen_l" tags="large shield hittable">
+			<connection name="con_shieldgen_l" tags="large shield hittable standard">
 				<offset>
 					<position x="-2.2831" y="-54.5329" z="232.0287"/>
 					<quaternion qw="-1.8267948965247504e-06" qx="0.0" qy="0.009939995994160865" qz="-0.9999505970178222"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_m_turret_left-side_2" tags="turret medium standard hittable">
+			<connection group="left-side" name="con_m_turret_left-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-56.386199999999995" y="-60.73349999999999" z="383.312"/>
 					<quaternion qw="-0.3541517054711761" qx="-0.0004703995193807856" qy="-0.0012914945054967497" qz="-0.9351869761058972"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_m_turret_right-side_2" tags="turret medium standard hittable">
+			<connection group="right-side" name="con_m_turret_right-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="52.186199999999995" y="-60.73349999999999" z="383.312"/>
 					<quaternion qw="-0.3541517054711761" qx="-0.0004703995193807856" qy="0.0012914945054967497" qz="0.9351869761058972"/>
@@ -305,181 +305,181 @@
 					<quaternion qw="-0.9934466054870484" qx="0.11427175003892026" qy="0.0002204787111415283" qz="-0.002400120505578514"/>
 				</offset>
 			</connection>
-			<connection group="back" name="con_shieldgen_m_left-back_1" tags="medium shield hittable">
+			<connection group="back" name="con_shieldgen_m_left-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-16.441300000000002" y="-69.271" z="-146.9962"/>
 					<quaternion qw="-0.5046278290748335" qx="0.007866725152244061" qy="-0.0010014707173620623" qz="-0.8633005651654596"/>
 				</offset>
 			</connection>
-			<connection group="back" name="con_shieldgen_m_right-back_1" tags="medium shield hittable">
+			<connection group="back" name="con_shieldgen_m_right-back_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="12.241300000000002" y="-69.271" z="-146.9962"/>
 					<quaternion qw="-0.5046278290748335" qx="0.007866725152244061" qy="0.0010014707173620623" qz="0.8633005651654596"/>
 				</offset>
 			</connection>
-			<connection group="wing" name="con_shieldgen_m_left-wing_1" tags="medium shield hittable">
+			<connection group="wing" name="con_shieldgen_m_left-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-106.6416" y="-52.920100000000005" z="1.6457"/>
 					<quaternion qw="-0.49715506127016434" qx="0.5166525695680564" qy="-0.4805639206950215" qz="-0.5049408733093536"/>
 				</offset>
 			</connection>
-			<connection group="wing" name="con_shieldgen_m_right-wing_1" tags="medium shield hittable">
+			<connection group="wing" name="con_shieldgen_m_right-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="103.4416" y="-52.920100000000005" z="1.6457"/>
 					<quaternion qw="-0.49715506127016434" qx="0.5166525695680564" qy="0.4805639206950215" qz="0.5049408733093536"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_shieldgen_m_left-side_2" tags="medium shield hittable">
+			<connection group="left-side" name="con_shieldgen_m_left-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-70.2127" y="-48.8335" z="294.66429999999997"/>
 					<quaternion qw="-0.354152173065125" qx="-0.0005592422632562036" qy="-0.001257827498460859" qz="-0.9351867960099335"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_shieldgen_m_right-side_2" tags="medium shield hittable">
+			<connection group="right-side" name="con_shieldgen_m_right-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="66.0127" y="-48.8335" z="294.66429999999997"/>
 					<quaternion qw="-0.354152173065125" qx="-0.0005592422632562036" qy="0.001257827498460859" qz="0.9351867960099335"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_shieldgen_m_left-side_1" tags="medium shield hittable">
+			<connection group="left-side" name="con_shieldgen_m_left-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-73.6684" y="-30.529899999999998" z="295.9158"/>
 					<quaternion qw="-0.9369212982947525" qx="-0.00018595545543486695" qy="0.0004984445102445869" qz="-0.3495399802244577"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_shieldgen_m_right-side_1" tags="medium shield hittable">
+			<connection group="right-side" name="con_shieldgen_m_right-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="69.4684" y="-30.529899999999998" z="295.9158"/>
 					<quaternion qw="-0.9369212982947525" qx="-0.00018595545543486695" qy="-0.0004984445102445869" qz="0.3495399802244577"/>
 				</offset>
 			</connection>
-			<connection group="back" name="con_m_turret_left-back_1" tags="turret medium standard hittable">
+			<connection group="back" name="con_m_turret_left-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-18.5413" y="-64.2424" z="-190.0697"/>
 					<quaternion qw="-0.4878039528085892" qx="-0.0021142930747225126" qy="0.011033257709090765" qz="-0.8728809200649505"/>
 				</offset>
 			</connection>
-			<connection group="back" name="con_m_turret_right-back_1" tags="turret medium standard hittable">
+			<connection group="back" name="con_m_turret_right-back_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="14.3413" y="-64.2424" z="-190.0697"/>
 					<quaternion qw="-0.4878039528085892" qx="-0.0021142930747225126" qy="-0.011033257709090765" qz="0.8728809200649505"/>
 				</offset>
 			</connection>
-			<connection group="wing" name="con_m_turret_left-wing_1" tags="turret medium standard hittable">
+			<connection group="wing" name="con_m_turret_left-wing_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-107.5669" y="-36.4073" z="-13.0682"/>
 					<quaternion qw="-0.7074988786448261" qx="0.02213359420052173" qy="0.014033231585930585" qz="-0.7062283689680952"/>
 				</offset>
 			</connection>
-			<connection group="wing" name="con_m_turret_right-wing_1" tags="turret medium standard hittable">
+			<connection group="wing" name="con_m_turret_right-wing_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="104.3669" y="-36.4073" z="-13.0682"/>
 					<quaternion qw="-0.7074988786448261" qx="0.02213359420052173" qy="-0.014033231585930585" qz="0.7062283689680952"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_m_turret_left-side_4" tags="turret medium standard hittable">
+			<connection group="left-side" name="con_m_turret_left-side_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.51010000000001" y="-56.318999999999996" z="164.2995"/>
 					<quaternion qw="-0.38886731866551155" qx="-0.003751508722863343" qy="0.001636217949853953" qz="-0.9212846777446254"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_m_turret_right-side_4" tags="turret medium standard hittable">
+			<connection group="right-side" name="con_m_turret_right-side_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="60.31010000000001" y="-56.318999999999996" z="164.2995"/>
 					<quaternion qw="-0.38886731866551155" qx="-0.003751508722863343" qy="-0.001636217949853953" qz="0.9212846777446254"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_m_turret_left-side_3" tags="turret medium standard hittable">
+			<connection group="left-side" name="con_m_turret_left-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-68.6703" y="-23.152800000000003" z="164.2388"/>
 					<quaternion qw="-0.9193014562114294" qx="-0.003533720869428408" qy="0.00825636820578445" qz="-0.39345162067071576"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_m_turret_right-side_3" tags="turret medium standard hittable">
+			<connection group="right-side" name="con_m_turret_right-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.4703" y="-23.152800000000003" z="164.2388"/>
 					<quaternion qw="-0.9193014562114294" qx="-0.003533720869428408" qy="-0.00825636820578445" qz="0.39345162067071576"/>
 				</offset>
 			</connection>
-			<connection group="left-side" name="con_m_turret_left-side_1" tags="turret medium standard hittable">
+			<connection group="left-side" name="con_m_turret_left-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-66.5504" y="-23.2835" z="383.3124"/>
 					<quaternion qw="-0.9372213821480228" qx="3.4873497207790306e-06" qy="-9.067109274025478e-06" qz="-0.34873497207790305"/>
 				</offset>
 			</connection>
-			<connection group="right-side" name="con_m_turret_right-side_1" tags="turret medium standard hittable">
+			<connection group="right-side" name="con_m_turret_right-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="62.3504" y="-23.2835" z="383.3124"/>
 					<quaternion qw="-0.9372213821480228" qx="3.4873497207790306e-06" qy="9.067109274025478e-06" qz="0.34873497207790305"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_shieldgen_m_left-front_2" tags="medium shield hittable">
+			<connection group="left-front" name="con_shieldgen_m_left-front_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-67.96029999999999" y="-48.0997" z="509.70899999999995"/>
 					<quaternion qw="-0.32974440661950327" qx="-0.004854410171996098" qy="-0.001677613161345209" qz="-0.9440562730150754"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_shieldgen_m_right-front_2" tags="medium shield hittable">
+			<connection group="right-front" name="con_shieldgen_m_right-front_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="63.76029999999999" y="-48.0997" z="509.70899999999995"/>
 					<quaternion qw="-0.32974440661950327" qx="-0.004854410171996098" qy="0.001677613161345209" qz="0.9440562730150754"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable">
+			<connection group="left-front" name="con_shieldgen_m_left-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-68.0004" y="-27.159100000000002" z="509.7087"/>
 					<quaternion qw="-0.9447086066373812" qx="-0.002589840823997904" qy="-7.017294711769454e-05" qz="-0.32790080259969107"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable">
+			<connection group="right-front" name="con_shieldgen_m_right-front_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="63.8004" y="-27.159100000000002" z="509.7087"/>
 					<quaternion qw="-0.9447086066373812" qx="-0.002589840823997904" qy="7.017294711769454e-05" qz="0.32790080259969107"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_4" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-46.0719" y="-67.50779999999999" z="531.096"/>
 					<quaternion qw="-0.3233157353343331" qx="-0.00889702578375233" qy="-0.005217847284791569" qz="-0.9462349350384053"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_4" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="41.8719" y="-67.50779999999999" z="531.096"/>
 					<quaternion qw="-0.3233157353343331" qx="-0.00889702578375233" qy="0.005217847284791569" qz="0.9462349350384053"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_3" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-67.74329999999999" y="-49.978899999999996" z="563.153"/>
 					<quaternion qw="-0.31703950710477563" qx="-0.007398565448642644" qy="-0.0009066822931550274" qz="-0.9483830397530748"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_3" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="63.54329999999999" y="-49.978899999999996" z="563.153"/>
 					<quaternion qw="-0.31703950710477563" qx="-0.007398565448642644" qy="0.0009066822931550274" qz="0.9483830397530748"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-67.6894" y="-25.225900000000003" z="563.1525"/>
 					<quaternion qw="-0.9469657182078056" qx="-0.004006720050499433" qy="0.0018483161224214241" qz="-0.3213043081894848"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="63.4894" y="-25.225900000000003" z="563.1525"/>
 					<quaternion qw="-0.9469657182078056" qx="-0.004006720050499433" qy="-0.0018483161224214241" qz="0.3213043081894848"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable">
+			<connection group="left-front" name="con_m_turret_left-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-47.085300000000004" y="-8.165799999999999" z="531.0956"/>
 					<quaternion qw="-0.9448175848336366" qx="-0.008493934643584576" qy="0.000347580401760384" qz="-0.3274865854523946"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable">
+			<connection group="right-front" name="con_m_turret_right-front_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="42.885300000000004" y="-8.165799999999999" z="531.0956"/>
 					<quaternion qw="-0.9448175848336366" qx="-0.008493934643584576" qy="-0.000347580401760384" qz="0.3274865854523946"/>

--- a/assets/units/size_l/ship_spl_l_panther.xml
+++ b/assets/units/size_l/ship_spl_l_panther.xml
@@ -239,7 +239,7 @@
 					<quaternion qw="-0.9997572942901874" qx="-0.020781156308275865" qy="0.0010041504781469262" qz="-0.007244842156450359"/>
 				</offset>
 			</connection>
-			<connection group="enggroup" name="con_engine_l" tags="engine large">
+			<connection group="enggroup" name="con_engine_l" tags="engine large standard">
 				<offset>
 					<position x="-1.5667" y="-47.7941" z="-223.2353"/>
 				</offset>

--- a/assets/units/size_l/ship_spl_l_viper.xml
+++ b/assets/units/size_l/ship_spl_l_viper.xml
@@ -384,17 +384,17 @@
 					<quaternion qw="-0.6563867627351581" qx="0.656387008035308" qy="0.262975772067044" qz="0.262975772067044"/>
 				</offset>
 			</connection>
-			<connection group="group_engine" name="con_engine_l_1" tags="engine mediumlarge">
+			<connection group="group_engine" name="con_engine_l_1" tags="engine mediumlarge standard">
 				<offset>
 					<position x="-12.5543" y="2.5" z="-645.4905"/>
 				</offset>
 			</connection>
-			<connection group="group_engine" name="con_engine_l_2" tags="engine mediumlarge">
+			<connection group="group_engine" name="con_engine_l_2" tags="engine mediumlarge standard">
 				<offset>
 					<position x="12.5543" y="2.5" z="-645.4905"/>
 				</offset>
 			</connection>
-			<connection group="group_engine" name="con_engine_l_3" tags="engine mediumlarge">
+			<connection group="group_engine" name="con_engine_l_3" tags="engine mediumlarge standard">
 				<offset>
 					<position x="0.0" y="65.0" z="-657.4905"/>
 				</offset>

--- a/assets/units/size_l/ship_spl_l_viper.xml
+++ b/assets/units/size_l/ship_spl_l_viper.xml
@@ -413,112 +413,112 @@
 				</offset>
 			</connection>
 			<!-- turrets and shields -->
-			<connection group="group_turret_m_top_2" name="con_m_turret_5" tags="turret medium standard hittable">
+			<connection group="group_turret_m_top_2" name="con_m_turret_5" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0.27799999999999997" y="88.3878" z="209.43239999999997"/>
 					<quaternion qw="-0.9968064993900115" qx="-0.07885328837797144" qy="0.0" qz="-0.012608000864978743"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_top_2" name="con_m_turret_6" tags="turret medium standard hittable">
+			<connection group="group_turret_m_top_2" name="con_m_turret_6" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0.1658" y="108.09930000000001" z="85.625"/>
 					<quaternion qw="-0.9968064993900115" qx="-0.07885328837797144" qy="0.0" qz="-0.012608000864978743"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_top_2" name="con_m_turret_7" tags="turret medium standard hittable">
+			<connection group="group_turret_m_top_2" name="con_m_turret_7" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0.2702" y="127.44740000000002" z="-35.8655"/>
 					<quaternion qw="-0.9968064993900115" qx="-0.07885328837797144" qy="0.0" qz="-0.012608000864978743"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_top_2" name="con_shieldgen_m_5" tags="medium shield hittable">
+			<connection group="group_turret_m_top_2" name="con_shieldgen_m_5" tags="medium shield hittable standard">
 				<offset>
 					<position x="0.1709" y="97.9439" z="149.4023"/>
 					<quaternion qw="-0.9968028649608931" qx="-0.07881923869814043" qy="-0.002685446011737294" qz="-0.012820467874421874"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_top_2" name="con_shieldgen_m_6" tags="medium shield hittable">
+			<connection group="group_turret_m_top_2" name="con_shieldgen_m_6" tags="medium shield hittable standard">
 				<offset>
 					<position x="0.0452" y="117.93020000000001" z="23.8673"/>
 					<quaternion qw="-0.9968028649608931" qx="-0.07881923869814043" qy="-0.002685446011737294" qz="-0.012820467874421874"/>
 				</offset>
 			</connection>
 			
-			<connection group="group_turret_m_bot_1" name="con_m_turret_14" tags="turret medium standard missile hittable ">
+			<connection group="group_turret_m_bot_1" name="con_m_turret_14" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-6.2467" y="-112.3432" z="410.6627"/>
 					<quaternion qw="-0.614337704622083" qx="-0.0030449181839021944" qy="-0.0007132951640962901" qz="-0.7890370107687803"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_1" name="con_shieldgen_m_9" tags="medium shield hittable">
+			<connection group="group_turret_m_bot_1" name="con_shieldgen_m_9" tags="medium shield hittable standard">
 				<offset>
 					<position x="-6.3426" y="-112.59410000000001" z="378.9441"/>
 					<quaternion qw="-0.6143380991436105" qx="-0.003961785970643312" qy="-0.0" qz="-0.7890329550738285"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_1" name="con_m_turret_16" tags="turret medium standard missile hittable ">
+			<connection group="group_turret_m_bot_1" name="con_m_turret_16" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="6.24670" y="-112.3432" z="410.6627"/>
 					<quaternion qw="-0.614337704622083" qx="-0.0030449181839021944" qy="0.0007132951640962901" qz="0.7890370107687803"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_1" name="con_shieldgen_m_10" tags="medium shield hittable">
+			<connection group="group_turret_m_bot_1" name="con_shieldgen_m_10" tags="medium shield hittable standard">
 				<offset>
 					<position x="6.3426" y="-112.59410000000001" z="378.9441"/>
 					<quaternion qw="-0.6143380991436105" qx="-0.003961785970643312" qy="0.0" qz="0.7890329550738285"/>
 				</offset>
 			</connection>
 			
-			<connection group="group_turret_m_bot_3" name="con_m_turret_22" tags="turret medium standard missile hittable ">
+			<connection group="group_turret_m_bot_3" name="con_m_turret_22" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-12.729299999999999" y="-55.6044" z="-532.591"/>
 					<quaternion qw="-0.00483330797632214" qx="-0.8655898015657081" qy="0.5006691010846936" qz="-0.007834907688617516"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_3" name="con_shieldgen_m_13" tags="medium shield hittable">
+			<connection group="group_turret_m_bot_3" name="con_shieldgen_m_13" tags="medium shield hittable standard">
 				<offset>
 					<position x="-13.1585" y="-54.834799999999994" z="-510.12649999999996"/>
 					<quaternion qw="-0.5006719294195731" qx="0.007198639121230475" qy="-0.004464956780580422" qz="-0.8655956693786262"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_3" name="con_m_turret_23" tags="turret medium standard missile hittable ">
+			<connection group="group_turret_m_bot_3" name="con_m_turret_23" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="12.729299999999999" y="-55.6044" z="-532.591"/>
 					<quaternion qw="-0.00483330797632214" qx="-0.8655898015657081" qy="-0.5006691010846936" qz="0.007834907688617516"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_m_bot_3" name="con_shieldgen_m_14" tags="medium shield hittable">
+			<connection group="group_turret_m_bot_3" name="con_shieldgen_m_14" tags="medium shield hittable standard">
 				<offset>
 					<position x="13.1585" y="-54.834799999999994" z="-510.12649999999996"/>
 					<quaternion qw="-0.5006719294195731" qx="0.007198639121230475" qy="0.004464956780580422" qz="0.8655956693786262"/>
 				</offset>
 			</connection>
 			
-			<connection group="group_turret_l" name="con_l_turret_1" tags="turret large standard hittable">
+			<connection group="group_turret_l" name="con_l_turret_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-25.3747" y="-56.1555" z="257.56489999999997"/>
 					<quaternion qw="-0.6106069872561715" qx="-0.008723152153402513" qy="-0.0004331878554617498" qz="-0.7918856142642902"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_l" name="con_shieldgen_m_1" tags="medium shield hittable">
+			<connection group="group_turret_l" name="con_shieldgen_m_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-31.853900000000003" y="-20.204900000000002" z="255.44299999999998"/>
 					<quaternion qw="-0.6106014437047729" qx="-0.00596804746544589" qy="-0.002557960896150507" qz="-0.7919114320371635"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_l" name="con_l_turret_2" tags="turret large standard hittable">
+			<connection group="group_turret_l" name="con_l_turret_2" tags="turret large standard hittable combat">
 				<offset>
 					<position x="25.3747" y="-56.1555" z="257.56489999999997"/>
 					<quaternion qw="-0.6106069872561715" qx="-0.008723152153402513" qy="0.0004331878554617498" qz="0.7918856142642902"/>
 				</offset>
 			</connection>
-			<connection group="group_turret_l" name="con_shieldgen_m_2" tags="medium shield hittable">
+			<connection group="group_turret_l" name="con_shieldgen_m_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="31.853900000000003" y="-20.204900000000002" z="255.44299999999998"/>
 					<quaternion qw="-0.6106014437047729" qx="-0.00596804746544589" qy="0.002557960896150507" qz="0.7919114320371635"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l" tags="large shield hittable">
+			<connection name="con_shieldgen_l" tags="large shield hittable standard">
 				<offset>
 					<position x="-0.11770000000000001" y="-106.37970000000001" z="-330.4686"/>
 					<quaternion qw="-0.42284211937232896" qx="0.5691012990050134" qy="0.4208083292375615" qz="-0.5659051189022904"/>

--- a/assets/units/size_l/ship_tel_l_destroyer_01.xml
+++ b/assets/units/size_l/ship_tel_l_destroyer_01.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <diff>
 	<replace sel="//components/component/connections/connection[@name='con_turret_l_01']">
-		<connection group="group_front_bottom_right" name="con_turret_l_01" tags="turret large standard hittable">
+		<connection group="group_front_bottom_right" name="con_turret_l_01" tags="turret large standard hittable combat">
 			<offset>
 				<position x="214.017" y="-123.117" z="173.861"/>
 				<quaternion qw="-0.49502953787182186" qx="-0.08989568979687966" qy="0.15144428713833416" qz="0.8508402608501289"/>
@@ -10,7 +10,7 @@
 	</replace>
 
 	<replace sel="//components/component/connections/connection[@name='con_shield_m_007']">
-		<connection group="group_front_bottom_right" name="con_shield_m_007" tags="medium shield hittable">
+		<connection group="group_front_bottom_right" name="con_shield_m_007" tags="medium shield hittable standard">
 			<offset>
 				<position x="161.76839999999999" y="-93.02629999999999" z="264.7175"/>
 				<quaternion qw="-0.45652795774209465" qx="-0.22516657757013966" qy="0.3788557409382717" qz="0.7728845733376333"/>
@@ -19,7 +19,7 @@
 	</replace>
 
 	<replace sel="//components/component/connections/connection[@name='con_turret_l_02']">
-		<connection group="group_front_bottom_left" name="con_turret_l_02" tags="turret large standard hittable">
+		<connection group="group_front_bottom_left" name="con_turret_l_02" tags="turret large standard hittable combat">
 			<offset>
 				<position x="-214.017" y="-123.117" z="173.861"/>
 				<quaternion qw="-0.494371222228854" qx="-0.08448250460021964" qy="-0.14872971519294353" qz="-0.8522554035423001"/>
@@ -28,7 +28,7 @@
 	</replace>
 
 		<replace sel="//components/component/connections/connection[@name='con_shield_m_008']">
-        <connection group="group_front_bottom_left" name="con_shield_m_008" tags="medium shield hittable">
+        <connection group="group_front_bottom_left" name="con_shield_m_008" tags="medium shield hittable standard">
 			<offset>
 				<position x="-161.768" y="-93.02629999999999" z="264.7175"/>
 				<quaternion qw="-0.4582060249600056" qx="-0.22173146197573101" qy="-0.3768243800276085" qz="-0.773877111741434"/>
@@ -37,7 +37,7 @@
 	</replace>
 
 <add sel="//components/component/connections">
-			<connection name="con_shield_l_04" tags="large shield hittable ">
+			<connection name="con_shield_l_04" tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="-51" z="-100"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="0"/>

--- a/assets/units/size_l/ship_tel_l_shrike_a.xml
+++ b/assets/units/size_l/ship_tel_l_shrike_a.xml
@@ -521,7 +521,7 @@
 						<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="-0.0" qz="0.7071067811865369"/>
 					</offset>
 				</connection>
-				<connection name="con_engine_l_4" group="group_back_mid_mid" tags="engine large">
+				<connection name="con_engine_l_4" group="group_back_mid_mid" tags="engine large standard">
 					<offset>
 						<position x="-0.0" y="-6.0511" z="-352.9369"/>
 					</offset>

--- a/assets/units/size_l/ship_tel_l_shrike_a.xml
+++ b/assets/units/size_l/ship_tel_l_shrike_a.xml
@@ -324,7 +324,7 @@
 					<position x="1.259786E-05" y="1.259786E-05" z="295.2055"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_002" group="group_front_top_center " tags="shield medium hittable ">
+			<connection name="con_shield_m_002" group="group_front_top_center " tags="shield medium hittable standard">
 				<offset>
 					<position x="-16.32245" y="198.1235" z="158.0919"/>
 					<quaternion qx="3.638484E-02" qy="-0.9841354" qz="-0.1735295" qw="6.415701E-03"/>
@@ -336,13 +336,13 @@
 					<quaternion qx="8.018163E-02" qy="-0.1540275" qz="-0.873535" qw="0.4547341"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_001" group="group_front_bottom_left " tags="shield medium hittable ">
+			<connection name="con_shield_m_001" group="group_front_bottom_left " tags="shield medium hittable standard">
 				<offset>
 					<position x="-166.1511" y="-123.0468" z="157.291"/>
 					<quaternion qx="-0.8735353" qy="0.4547335" qz="8.018147E-02" qw="-0.1540276"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_m_003" group="group_front_bottom_right " tags="shield medium hittable ">
+			<connection name="con_shield_m_003" group="group_front_bottom_right " tags="shield medium hittable standard">
 				<offset>
 					<position x="185.8434" y="-89.39158" z="156.3843"/>
 					<quaternion qx="-0.8305787" qy="-0.5291364" qz="-0.0933011" qw="-0.1464534"/>

--- a/assets/units/size_l/ship_tel_l_shrike_a.xml
+++ b/assets/units/size_l/ship_tel_l_shrike_a.xml
@@ -270,7 +270,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="0" y="151.68" z="112.366"/>
 				</offset>
@@ -297,12 +297,12 @@
 					<quaternion qx="-1" qy="-0" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="-135.3741" y="-82.4471" z="112.366"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large standard ">
 				<offset>
 					<position x="134.7433" y="-82.2897" z="112.366"/>
 				</offset>
@@ -330,7 +330,7 @@
 					<quaternion qx="3.638484E-02" qy="-0.9841354" qz="-0.1735295" qw="6.415701E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group_front_bottom_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_015" group="group_front_bottom_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="167.4956" y="-121.7588" z="156.3933"/>
 					<quaternion qx="8.018163E-02" qy="-0.1540275" qz="-0.873535" qw="0.4547341"/>
@@ -348,13 +348,13 @@
 					<quaternion qx="-0.8305787" qy="-0.5291364" qz="-0.0933011" qw="-0.1464534"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group_front_bottom_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_014" group="group_front_bottom_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-185.0206" y="-90.63371" z="157.2302"/>
 					<quaternion qx="-9.330112E-02" qy="-0.1464533" qz="-0.8305786" qw="-0.5291367"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group_front_top_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_013" group="group_front_top_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="18.13968" y="198.4102" z="157.1296"/>
 					<quaternion qx="-0.1733444" qy="1.026091E-02" qz="5.819372E-02" qw="-0.9830869"/>
@@ -399,123 +399,123 @@
 						</offset>
 				</connection>
 		
-				<connection name="con_weapon_01" tags="weapon large standard tel_destroyer_01 ">
+				<connection name="con_weapon_01" tags="weapon large standard tel_destroyer_01 combat">
 					<offset>
 						<position x="-0.0025" y="-42" z="297"/>
 						<quaternion qx="-0" qy="-0" qz="0" qw="0"/>
 					</offset>
 				</connection>
 
-				<connection group="lob" name="con_shieldgen_m_lob_2" tags="medium shield hittable">
+				<connection group="lob" name="con_shieldgen_m_lob_2" tags="medium shield hittable standard">
 					<offset>
 						<position x="0.0704" y="69.5272" z="292.9771"/>
 						<quaternion qw="-0.8258186464313383" qx="-0.5639357793280297" qy="0.0" qz="-0.0"/>
 					</offset>
 				</connection>
-				<connection group="lob" name="con_shieldgen_m_lob_3" tags="medium shield hittable">
+				<connection group="lob" name="con_shieldgen_m_lob_3" tags="medium shield hittable standard">
 					<offset>
 						<position x="-64.2217" y="-41.3692" z="293.16909999999996"/>
 						<quaternion qw="-0.4165624816303873" qx="-0.2873260200218131" qy="-0.4852713592385569" qz="-0.7130435926499314"/>
 					</offset>
 				</connection>
-				<connection group="lob" name="con_shieldgen_m_lob_1" tags="medium shield hittable">
+				<connection group="lob" name="con_shieldgen_m_lob_1" tags="medium shield hittable standard">
 					<offset>
 						<position x="64.5447" y="-42.084500000000006" z="292.9201"/>
 						<quaternion qw="-0.4147397957833558" qx="-0.28465013031467185" qy="0.4868296773895893" qz="0.7141162862714789"/>
 					</offset>
 				</connection>
-				<connection group="lob" name="con_m_turret_lob_3" tags="turret medium standard hittable">
+				<connection group="lob" name="con_m_turret_lob_3" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="86.3929" y="-54.8076" z="281.37780000000004"/>
 						<quaternion qw="-0.4290527411212524" qx="-0.2533679374262071" qy="0.44157152522496074" qz="0.7461454427464065"/>
 					</offset>
 				</connection>
-				<connection group="lob" name="con_m_turret_lob_2" tags="turret medium standard hittable">
+				<connection group="lob" name="con_m_turret_lob_2" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="-86.4126" y="-54.831700000000005" z="281.3617"/>
 						<quaternion qw="-0.4249406556835097" qx="-0.24644014080930404" qy="-0.4455299700019529" qz="-0.7484622515365877"/>
 					</offset>
 				</connection>
-				<connection group="lob" name="con_m_turret_lob_1" tags="turret medium standard hittable">
+				<connection group="lob" name="con_m_turret_lob_1" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="0.16149999999999998" y="94.93549999999999" z="281.3887"/>
 						<quaternion qw="-0.8607271377395245" qx="-0.5090665912812641" qy="0.0" qz="-0.0"/>
 					</offset>
 				</connection>
 
-				<connection group="dock-group" name="con_shieldgen_m_dock-group_1" tags="medium shield hittable">
+				<connection group="dock-group" name="con_shieldgen_m_dock-group_1" tags="medium shield hittable standard">
 					<offset>
 						<position x="0.0" y="60.9765" z="-225.56449999999998"/>
 						<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>
 					</offset>
 				</connection>
-				<connection group="dock-group" name="con_m_turret_dock-group_2" tags="turret medium standard hittable">
+				<connection group="dock-group" name="con_m_turret_dock-group_2" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="17.0" y="60.9765" z="-225.56449999999998"/>
 						<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>
 					</offset>
 				</connection>
-				<connection group="dock-group" name="con_m_turret_dock-group_1" tags="turret medium standard hittable">
+				<connection group="dock-group" name="con_m_turret_dock-group_1" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="-17.0" y="60.9765" z="-225.56400000000002"/>
 						<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0"/>
 					</offset>
 				</connection>
-				<connection group="left-turret-line" name="con_shieldgen_m_left-turret-line_1" tags="medium shield hittable">
+				<connection group="left-turret-line" name="con_shieldgen_m_left-turret-line_1" tags="medium shield hittable standard">
 					<offset>
 						<position x="-93.8659" y="-57.3423" z="67.52420000000001"/>
 						<quaternion qw="-0.49999701324566737" qx="-8.660271281801233e-07" qy="8.660271281801233e-07" qz="-0.8660271281801234"/>
 					</offset>
 				</connection>
-				<connection group="right-turret-line" name="con_shieldgen_m_right-turret-line_1" tags="medium shield hittable">
+				<connection group="right-turret-line" name="con_shieldgen_m_right-turret-line_1" tags="medium shield hittable standard">
 					<offset>
 						<position x="93.8659" y="-57.3423" z="67.52420000000001"/>
 						<quaternion qw="-0.49999701324566737" qx="-8.660271281801233e-07" qy="-8.660271281801233e-07" qz="0.8660271281801234"/>
 					</offset>
 				</connection>
-				<connection group="left-turret-line" name="con_m_turret_left-turret-line_3" tags="turret medium standard hittable">
+				<connection group="left-turret-line" name="con_m_turret_left-turret-line_3" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="-94.1889" y="-56.7828" z="15.126500000000002"/>
 						<quaternion qw="-0.5000035084350662" qx="0.0006183404819263198" qy="-0.00035680151057933295" qz="-0.8660230839304198"/>
 					</offset>
 				</connection>
-				<connection group="right-turret-line" name="con_m_turret_right-turret-line_3" tags="turret medium standard hittable">
+				<connection group="right-turret-line" name="con_m_turret_right-turret-line_3" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="94.1889" y="-56.7828" z="15.126500000000002"/>
 						<quaternion qw="-0.5000035084350662" qx="0.0006183404819263198" qy="0.00035680151057933295" qz="0.8660230839304198"/>
 					</offset>
 				</connection>
-				<connection group="left-turret-line" name="con_m_turret_left-turret-line_2" tags="turret medium standard hittable">
+				<connection group="left-turret-line" name="con_m_turret_left-turret-line_2" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="-92.99680000000001" y="-58.8476" z="-337.89250000000004"/>
 						<quaternion qw="-0.4999996113248019" qx="0.0006183420884307857" qy="-0.00035680243758191" qz="-0.8660253339366747"/>
 					</offset>
 				</connection>
-				<connection group="right-turret-line" name="con_m_turret_right-turret-line_2" tags="turret medium standard hittable">
+				<connection group="right-turret-line" name="con_m_turret_right-turret-line_2" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="92.99680000000001" y="-58.8476" z="-337.89250000000004"/>
 						<quaternion qw="-0.4999996113248019" qx="0.0006183420884307857" qy="0.00035680243758191" qz="0.8660253339366747"/>
 					</offset>
 				</connection>
-				<connection group="left-turret-line" name="con_m_turret_left-turret-line_1" tags="turret medium standard hittable">
+				<connection group="left-turret-line" name="con_m_turret_left-turret-line_1" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="-93.0369" y="-58.778200000000005" z="-281.96659999999997"/>
 						<quaternion qw="-0.4999996113248019" qx="0.0006183420881757198" qy="-0.00035766846276830854" qz="-0.8660253335794396"/>
 					</offset>
 				</connection>
-				<connection group="right-turret-line" name="con_m_turret_right-turret-line_1" tags="turret medium standard hittable">
+				<connection group="right-turret-line" name="con_m_turret_right-turret-line_1" tags="turret medium standard hittable combat">
 					<offset>
 						<position x="93.0369" y="-58.778200000000005" z="-281.96659999999997"/>
 						<quaternion qw="-0.4999996113248019" qx="0.0006183420881757198" qy="0.00035766846276830854" qz="0.8660253335794396"/>
 					</offset>
 				</connection>
-				<connection name="con_shieldgen_l_2" tags="large shield hittable">
+				<connection name="con_shieldgen_l_2" tags="large shield hittable standard">
 					<offset>
 						<position x="-0.0" y="-113.85799999999999" z="-184.788"/>
 						<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="-0.0" qz="0.7071067811865369"/>
 					</offset>
 				</connection>
-				<connection name="con_shieldgen_l_1" tags="large shield hittable">
+				<connection name="con_shieldgen_l_1" tags="large shield hittable standard">
 					<offset>
 						<position x="-0.0" y="-113.85799999999999" z="-80.5891"/>
 						<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="-0.0" qz="0.7071067811865369"/>

--- a/assets/units/size_l/ship_ter_l_akita.xml
+++ b/assets/units/size_l/ship_ter_l_akita.xml
@@ -269,530 +269,530 @@
 				</offset>
 			</connection> -->
 			<!-- L Battery 01 -->
-			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="61.47" z="31.54"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="49.96" z="148.89"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="245.7"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_14" group="group_main_battery " tags="turret large standard highpower terronly">
+			<!-- <connection name="con_turret_laser_l_14" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="331.416"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.1495" y="49.95" z="102.893"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_013" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_013" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.1495" y="49.95" z="102.893"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_014" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_014" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.1495" y="49.95" z="188.689"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_015" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_015" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.1495" y="49.95" z="188.689"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 02 -->
-			<connection name="con_turret_laser_l_04" group="group_aft_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_04" group="group_aft_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="49.95" z="-150.49"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard highpower terronly">
+			<!-- <connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="-262.53"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_002" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="24.256" y="38.483" z="-214.586"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_016" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_016" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-24.256" y="38.483" z="-214.586"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 03 -->
-			<connection name="con_turret_laser_l_06" group="group_front_keel_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_06" group="group_front_keel_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-70.36" z="166.88"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_07" group="group_front_keel_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_07" group="group_front_keel_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-59.94" z="322.77"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group_front_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group_front_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="16.7112" y="-70.36" z="127.314"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_017" group="group_front_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_017" group="group_front_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-16.7112" y="-70.36" z="127.314"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
 			<!-- L Battery 04 -->
-			<!-- <connection name="con_turret_laser_l_08" group="group_aft_keel_battery " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_08" group="group_aft_keel_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-70.36" z="-247.3"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_10" group="group_aft_keel_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_10" group="group_aft_keel_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-69.7332" z="-347.631"/>
 					<rotation yaw="0" pitch="-1.45314" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_turret_laser_l_11" group="group_aft_keel_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_11" group="group_aft_keel_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-67.7268" z="-426.722"/>
 					<rotation yaw="180" pitch="1.44379" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group_aft_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group_aft_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.8775" y="-70.36" z="-290.505"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_018" group="group_aft_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_018" group="group_aft_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.8775" y="-70.36" z="-290.505"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgen_019" group="group_aft_keel_battery " tags="medium shield hittable ">
+			<!-- <connection name="con_shieldgen_019" group="group_aft_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.8775" y="-68.36" z="-387.715"/>
 					<rotation yaw="90" pitch="0" roll="178.556"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_020" group="group_aft_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_020" group="group_aft_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.8775" y="-68.36" z="-387.715"/>
 					<rotation yaw="90" pitch="0" roll="178.556"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 05 -->
-			<connection name="con_turret_laser_l_09" group="group_front_bow_battery " tags="turret large missile standard ">
+			<connection name="con_turret_laser_l_09" group="group_front_bow_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="0 " y="29.93" z="667.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group_front_bow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group_front_bow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="18.0521" y="29.9317" z="704.933"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_021" group="group_front_bow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_021" group="group_front_bow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-18.0521" y="29.9317" z="704.933"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 06 -->
-			<connection name="con_turret_laser_l_12" group="group_forward_keel_battery " tags="turret large missile standard highpower terronly">
+			<connection name="con_turret_laser_l_12" group="group_forward_keel_battery " tags="turret large missile standard highpower terronly combat">
 				<offset>
 					<position x="0 " y="-59.9415" z="560.201"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_13" group="group_forward_keel_battery " tags="turret large missile standard highpower terronly">
+			<!-- <connection name="con_turret_laser_l_13" group="group_forward_keel_battery " tags="turret large missile standard highpower terronly combat">
 				<offset>
 					<position x="0 " y="-59.9415" z="438.219"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_022" group="group_forward_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_022" group="group_forward_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="20.669" y="-59.9511" z="500.054"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_023" group="group_forward_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_023" group="group_forward_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-20.669" y="-59.9511" z="500.054"/>
 					<rotation yaw="-90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Battery 01 Point Defense-->
-			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="22.6" z="869.9"/>
 					<rotation yaw="0" pitch="-2.61" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="61.33" z="-96.7 "/>
 					<rotation yaw="180" pitch="0" roll="0"/> 
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-59.95" z="500"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="61.3398" z="-81.7829"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- M Battery 02 Rear Defense-->
-			<connection name="con_turret_004" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_004" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="49.95" z="-205.4"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_005" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-66.21" z="-489.5"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group_rear_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group_rear_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="49.9586" z="-19.018"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- M Battery 03 Citadel Upper Defense-->
-			<!-- <connection name="con_turret_006" group="group_citadel_upper_defense " tags="turret medium standard hittable ">
+			<!-- <connection name="con_turret_006" group="group_citadel_upper_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-33.89" y="49.95" z="-41.05"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_citadel_upper_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_007" group="group_citadel_upper_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-33.89" y="49.95" z="-84.06"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_citadel_upper_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_008" group="group_citadel_upper_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="33.89" y="49.95" z="-41.05"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_citadel_upper_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_009" group="group_citadel_upper_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="33.89" y="49.95" z="-84.06"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group_citadel_upper_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group_citadel_upper_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="28.3042" y="49.9586" z="-104.405"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_024" group="group_citadel_upper_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_024" group="group_citadel_upper_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-28.3042" y="49.9586" z="-104.405"/>
 				</offset>
 			</connection> -->
 			<!-- M Battery 04 Citadel Defense I -->
-			<connection name="con_turret_010" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_010" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.12" y="38.48" z="-1.76"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_011" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.12" y="38.48" z="-84"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_012" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.12" y="38.48" z="-168.9"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_013" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.12" y="38.48" z="-1.76"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_014" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.12" y="38.48" z="-84"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group_citadel_defense_one " tags="turret medium standard hittable ">
+			<connection name="con_turret_015" group="group_citadel_defense_one " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.12" y="38.48" z="-168.9"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_009" group="group_citadel_defense_one " tags="medium shield hittable ">
+			<connection name="con_shieldgen_009" group="group_citadel_defense_one " tags="medium shield hittable standard ">
 				<offset>
 					<position x="93.3377" y="29.7894" z="-26.5132"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_025" group="group_citadel_defense_one " tags="medium shield hittable ">
+			<connection name="con_shieldgen_025" group="group_citadel_defense_one " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-93.3377" y="29.7894" z="-26.5132"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_026" group="group_citadel_defense_one " tags="medium shield hittable ">
+			<connection name="con_shieldgen_026" group="group_citadel_defense_one " tags="medium shield hittable standard ">
 				<offset>
 					<position x="93.3377" y="29.8198" z="-69.337"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_027" group="group_citadel_defense_one " tags="medium shield hittable ">
+			<connection name="con_shieldgen_027" group="group_citadel_defense_one " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-93.3377" y="29.8198" z="-69.337"/>
 				</offset>
 			</connection>
 			<!-- M Battery 05 Citadel Defense II-->
-			<!-- <connection name="con_turret_016" group="group_citadel_defense_two " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_016" group="group_citadel_defense_two " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-64.12" y="38.48" z="-42.64"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_017" group="group_citadel_defense_two " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_017" group="group_citadel_defense_two " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-64.12" y="38.48" z="-126.7"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_018" group="group_citadel_defense_two " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_018" group="group_citadel_defense_two " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="64.12" y="38.48" z="-42.64"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_019" group="group_citadel_defense_two " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_019" group="group_citadel_defense_two " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="64.12" y="38.48" z="-126.7"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_010" group="group_citadel_defense_two " tags="medium shield hittable ">
+			<connection name="con_shieldgen_010" group="group_citadel_defense_two " tags="medium shield hittable standard ">
 				<offset>
 					<position x="93.3377" y="29.8198" z="-127.622"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_028" group="group_citadel_defense_two " tags="medium shield hittable ">
+			<connection name="con_shieldgen_028" group="group_citadel_defense_two " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-93.3377" y="29.8198" z="-127.622"/>
 				</offset>
 			</connection> -->
 			<!-- M Battery 06 Neck Array-->
-			<connection name="con_turret_020" group="group_neck_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_020" group="group_neck_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="497.046"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_021" group="group_neck_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_021" group="group_neck_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="581.906"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_022" group="group_neck_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_022" group="group_neck_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="0" y="38.48" z="380.305"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_033" group="group_neck_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_033" group="group_neck_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="38.483" z="512.42"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_034" group="group_neck_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_034" group="group_neck_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="38.483" z="481.859"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- M Battery 07 Wing Array-->
-			<connection name="con_turret_023" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_023" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="178.475" y="-20.6499" z="-41.7311"/>
 					<rotation yaw="0" pitch="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_024" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_024" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="-178.475" y="-20.6499" z="-41.7311"/>
 					<rotation yaw="0" pitch="0" roll="-90"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_025" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_025" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="178.475" y="-20.6499" z="-358.154"/>
 					<rotation yaw="180" pitch="0" roll="-90"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_026" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_026" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="-178.475" y="-20.6499" z="-358.154"/>
 					<rotation yaw="-180" pitch="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_027" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_027" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="5.9059" y="-128.314" z="-50.3784"/>
 					<rotation yaw="0" pitch="0" roll="92.6488"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_028" group="group_wing_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_028" group="group_wing_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="-5.9059" y="-128.314" z="-50.3784"/>
 					<rotation yaw="0" pitch="0" roll="-92.6488"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_035" group="group_wing_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_035" group="group_wing_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="178.475" y="-20.6499" z="-200.079"/>
 					<rotation yaw="0" pitch="0" roll="90"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_036" group="group_wing_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_036" group="group_wing_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-178.475" y="-20.6499" z="-200.079"/>
 					<rotation yaw="0" pitch="0" roll="-90"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_037" group="group_wing_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_037" group="group_wing_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-179.062" z="-36.5094"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Battery 08 Keel Array-->
-			<connection name="con_turret_029" group="group_keel_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_029" group="group_keel_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="126.498" y="-52.3078" z="-174.164"/>
 					<rotation yaw="0" pitch="0" roll="165.498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_030" group="group_keel_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_030" group="group_keel_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="-126.498" y="-52.3078" z="-174.164"/>
 					<rotation yaw="0" pitch="0" roll="-165.498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_031" group="group_keel_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_031" group="group_keel_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="126.498" y="-52.3078" z="-226.165"/>
 					<rotation yaw="180" pitch="0" roll="-165.498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_032" group="group_keel_array " tags="turret medium standard missile hittable  terronly">
+			<connection name="con_turret_032" group="group_keel_array " tags="turret medium standard missile hittable terronly combat">
 				<offset>
 					<position x="-126.498" y="-52.3078" z="-226.165"/>
 					<rotation yaw="-180" pitch="0" roll="165.498"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_038" group="group_keel_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_038" group="group_keel_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="126.498" y="-52.3078" z="-200.19"/>
 					<rotation yaw="90" pitch="-165.498" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_039" group="group_keel_array " tags="medium shield hittable ">
+			<connection name="con_shieldgen_039" group="group_keel_array " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-126.498" y="-52.3078" z="-200.19"/>
 					<rotation yaw="90" pitch="165.498" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Engines -->
-			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-94.6647" y="1.2934" z="-489.296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="0" y="-4.5091" z="-489.296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-48.0267" y="-21.8656" z="-489.296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="48.0267" y="-21.8656" z="-489.296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="94.6647" y="1.2934" z="-489.296"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="58.6831" y="29.8455" z="-338.878"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_012" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_012" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-58.6831" y="29.8455" z="-338.878"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_029" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_029" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="58.6831" y="29.8455" z="-399.971"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_030" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_030" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-58.6831" y="29.8455" z="-399.971"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_031" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_031" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="58.6831" y="29.8455" z="-458.844"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_032" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_032" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-58.6831" y="29.8455" z="-458.844"/>
 				</offset>

--- a/assets/units/size_l/ship_ter_l_akita.xml
+++ b/assets/units/size_l/ship_ter_l_akita.xml
@@ -229,41 +229,41 @@
 				</offset>
 			</connection>
 			<!-- L Shields -->
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-354.644"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/> 
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_02" tags="large shield ">
+			<connection name="con_shieldgenerator_l_02" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-354.644"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_03" tags="large shield ">
+			<connection name="con_shieldgenerator_l_03" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-448.839"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_04" tags="large shield ">
+			<connection name="con_shieldgenerator_l_04" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-448.839"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_05" tags="large shield ">
+			<connection name="con_shieldgenerator_l_05" tags="large shield standard">
 				<offset>
 					<position x="0" y="29.93" z="-341.5"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgenerator_l_06" tags="large shield ">
+			<!-- <connection name="con_shieldgenerator_l_06" tags="large shield standard">
 				<offset>
 					<position x="34" y="29.93" z="-341.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_07" tags="large shield ">
+			<connection name="con_shieldgenerator_l_07" tags="large shield standard">
 				<offset>
 					<position x="-34" y="29.93" z="-341.5"/>
 				</offset>

--- a/assets/units/size_l/ship_ter_l_carrier_01.xml
+++ b/assets/units/size_l/ship_ter_l_carrier_01.xml
@@ -347,7 +347,7 @@
 					<position x="-5.803196" y="63.74717" z="-78.63259"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_01" group="group_front_down_mid" tags="turret large standard">
+			<connection name="con_turret_l_01" group="group_front_down_mid" tags="turret large standard combat">
 				<offset>
 					<position x="0" y="17.37175" z="-211.7072"/>
 				</offset>
@@ -370,7 +370,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large standard ">
 				<offset>
 					<position x="0" y="-10.3126" z="-268.6246"/>
 				</offset>
@@ -381,55 +381,55 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="3.814697E-06" y="18.53489" z="-255.043"/>
 					<quaternion qx="-1.192488E-08" qy="-1" qz="-4.371139E-08" qw="-5.212531E-16"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.57464" y="15.28368" z="39.6659"/>
 					<quaternion qx="-7.559556E-03" qy="0.0369222" qz="4.393085E-02" qw="-0.9983234"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-34.48405" y="14.81" z="89.637"/>
 					<quaternion qx="-7.906446E-03" qy="-3.546138E-02" qz="-4.464936E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-32.50572" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166875E-02" qy="-1.389165E-02" qz="-0.8546926" qw="-0.5179814"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-33.00225" z="-255.423"/>
 					<quaternion qx="1.139987E-14" qy="-1.509958E-07" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.430511E-05" y="-24.94496" z="-56.08788"/>
 					<quaternion qx="1.605792E-07" qy="2.614582E-02" qz="-0.9996581" qw="9.165257E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-32.69301" y="1.339282" z="206.0865"/>
 					<quaternion qx="-3.001889E-02" qy="-8.296681E-03" qz="-0.8737218" qw="-0.4854279"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-9.059906E-06" y="-27.85221" z="-36.66078"/>
 					<quaternion qx="3.264641E-07" qy="3.264641E-07" qz="-0.9999982" qw="-1.913082E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="16.16245" z="-273.7814"/>
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
@@ -452,24 +452,24 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_down_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_down_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="9.536743E-07" y="27.69783" z="-129.8475"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="27.855" y="14.914" z="63.727"/>
 					<quaternion qx="8.570193E-06" qy="-1.588322E-03" qz="5.340632E-03" qw="-0.9999845"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-27.85509" y="14.91373" z="63.72742"/>
 					<quaternion qx="-8.410671E-06" qy="-1.584657E-03" qz="-5.340394E-03" qw="-0.9999844"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.575" y="15.284" z="39.66653"/>
 					<quaternion qx="-7.562648E-03" qy="-3.692228E-02" qz="-4.392866E-02" qw="-0.9983235"/>
@@ -480,19 +480,19 @@
 					<position x="0" y="13.24893" z="89.36286"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="34.48043" y="14.81034" z="89.63728"/>
 					<quaternion qx="-7.905921E-03" qy="3.545943E-02" qz="4.465049E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="32.693" y="1.339282" z="206.0865"/>
 					<quaternion qx="3.002086E-02" qy="-8.297981E-03" qz="-0.8737201" qw="0.4854307"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="32.506" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166441E-02" qy="0.0138908" qz="0.8546929" qw="-0.5179813"/>

--- a/assets/units/size_l/ship_ter_l_carrier_01.xml
+++ b/assets/units/size_l/ship_ter_l_carrier_01.xml
@@ -435,7 +435,7 @@
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="5.193055E-06" y="-26.21284" z="-181.0515"/>
 					<quaternion qx="-1" qy="-4.371136E-08" qz="-7.549792E-08" qw="-3.258414E-07"/>

--- a/assets/units/size_l/ship_ter_l_makhaira.xml
+++ b/assets/units/size_l/ship_ter_l_makhaira.xml
@@ -229,31 +229,31 @@
 				</offset>
 			</connection>
 			<!-- L Shields -->
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-307.934"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/> 
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_02" tags="large shield ">
+			<connection name="con_shieldgenerator_l_02" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-307.934"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_03" tags="large shield ">
+			<connection name="con_shieldgenerator_l_03" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-402.129"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_04" tags="large shield ">
+			<connection name="con_shieldgenerator_l_04" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-402.129"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgenerator_l_05" tags="large shield ">
+			<!-- <connection name="con_shieldgenerator_l_05" tags="large shield standard">
 				<offset>
 					<position x="0" y="29.9413" z="-306.091"/>
 				</offset>

--- a/assets/units/size_l/ship_ter_l_makhaira.xml
+++ b/assets/units/size_l/ship_ter_l_makhaira.xml
@@ -259,393 +259,393 @@
 				</offset>
 			</connection> -->
 			<!-- L Battery 01 -->
-			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="68.8451" z="127.179"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="51.7373" z="219.65"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly">
+			<!-- <connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="38.4655" z="294.301"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.839" y="68.8451" z="171.791"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_012" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_012" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.839" y="68.8451" z="171.791"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_013" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_013" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.839" y="68.8451" z="85.3363"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_014" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_014" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.839" y="68.8451" z="85.3363"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 02 -->
-			<connection name="con_turret_laser_l_04" group="group_aft_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_04" group="group_aft_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="51.7373" z="-106.305"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="38.4655" z="-194.551"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_002" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.839" y="38.4655" z="-151.918"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_015" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_015" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.839" y="38.4655" z="-151.918"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 03 -->
-			<connection name="con_turret_laser_l_06" group="group_front_battery " tags="turret large missile standard ">
+			<connection name="con_turret_laser_l_06" group="group_front_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="0" y="38.4655" z="513.558"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_07" group="group_front_battery " tags="turret large missile standard ">
+			<!-- <connection name="con_turret_laser_l_07" group="group_front_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="64.3765" y="29.9413" z="513.558"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_003" group="group_front_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group_front_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="77.7061" y="29.9413" z="468.611"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_016" group="group_front_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_016" group="group_front_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-77.7061" y="29.9413" z="468.611"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 04 -->
-			<connection name="con_turret_laser_l_08" group="group_keel_battery " tags="turret large  standard  terronly">
+			<connection name="con_turret_laser_l_08" group="group_keel_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="74.3929 " y="-30.2651" z="517.68"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_09" group="group_keel_battery " tags="turret large  standard  terronly">
+			<connection name="con_turret_laser_l_09" group="group_keel_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="-74.3929 " y="-30.2651" z="517.68"/>
 					<rotation yaw="0" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="73.4624" y="-30.2651" z="476.009"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_017" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_017" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-73.4624" y="-30.2651" z="476.009"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
 			<!-- L Battery 05 -->
-			<!-- <connection name="con_turret_laser_l_10" group="group_keel_front " tags="turret large  standard  terronly">
+			<!-- <connection name="con_turret_laser_l_10" group="group_keel_front " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-59.2146" z="514.788"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_11" group="group_keel_front " tags="turret large  standard  terronly">
+			<connection name="con_turret_laser_l_11" group="group_keel_front " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-59.3215" z="424.806"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_027" group="group_keel_front " tags="medium shield hittable ">
+			<connection name="con_shieldgen_027" group="group_keel_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.79" y="-59.2146" z="469.963"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_028" group="group_keel_front " tags="medium shield hittable ">
+			<connection name="con_shieldgen_028" group="group_keel_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.79" y="-59.2146" z="469.963"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 07 -->
-			<!-- <connection name="con_turret_laser_l_12" group="group_keel_back " tags="turret large standard terronly">
+			<!-- <connection name="con_turret_laser_l_12" group="group_keel_back " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-70.2816" z="-189.818"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_turret_laser_l_13" group="group_keel_back " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_13" group="group_keel_back " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-70.0329" z="-291.48"/>
 					<rotation yaw="0" pitch="-1.44379" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_14" group="group_keel_back " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_14" group="group_keel_back " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-67.8725" z="-381.437"/>
 					<rotation yaw="180" pitch="1.44379" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_029" group="group_keel_back " tags="medium shield hittable ">
+			<connection name="con_shieldgen_029" group="group_keel_back " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.3771" y="-68.9035" z="-336.292"/>
 					<rotation yaw="90" pitch="0" roll="178.556"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_030" group="group_keel_back " tags="medium shield hittable ">
+			<connection name="con_shieldgen_030" group="group_keel_back " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.3771" y="-68.9035" z="-336.292"/>
 					<rotation yaw="90" pitch="0" roll="178.556"/>
 				</offset>
 			</connection>
 			<!-- M Battery 01 Point Defense-->
-			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="22.7367" z="716.922"/>
 					<rotation yaw="0" pitch="-2.61" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-66.2154" z="-441.34 "/>
 					<rotation yaw="180" pitch="0.672" roll="180"/> 
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-90.4503" z="53.8537"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-90.4503" z="22.3102"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_018" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_018" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-90.4503" z="34.1229"/>
 					<rotation yaw="-90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Battery 02 Citadel Defense-->
-			<connection name="con_turret_004" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_004" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.5042" y="38.4655" z="36.0541"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_005" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.5042" y="38.4655" z="-17.26"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_006" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.5042" y="38.4655" z="36.0541"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_007" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.5042" y="38.4655" z="-17.26"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_016" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_016" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.5042" y="38.4655" z="9.2169"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_017" group="group_citadel_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_017" group="group_citadel_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.5042" y="38.4655" z="9.2169"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group_citadel_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group_citadel_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="68.8451" z="68.8249"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_019" group="group_citadel_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_019" group="group_citadel_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="23.4444" y="68.8451" z="68.8249"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_020" group="group_citadel_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_020" group="group_citadel_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-23.4444" y="68.8451" z="68.8249"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- M Battery 03 Forward Defense-->
-			<connection name="con_turret_008" group="group_forward_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_forward_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="47.2063" y="-21.3383" z="771.461"/>
 					<rotation yaw="0" pitch="3.732" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_forward_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_forward_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-47.2063" y="-21.3383" z="771.461"/>
 					<rotation yaw="0" pitch="3.732" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group_forward_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group_forward_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-90.4503" z="10.2615"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Battery 04 Port Barrage-->
-			<connection name="con_turret_010" group="group_port_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_010" group="group_port_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="111.469" y="-72.9885" z="347.528"/>
 					<rotation yaw="0" pitch="0" roll="153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group_port_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_011" group="group_port_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="111.469" y="-72.9885" z="258.085"/>
 					<rotation yaw="0" pitch="0" roll="153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group_port_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_012" group="group_port_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="111.286" y="-072.1928" z="148.543"/>
 					<rotation yaw="0" pitch="-2.5" roll="153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group_port_barrage " tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group_port_barrage " tags="medium shield hittable standard ">
 				<offset>
 					<position x="111.469" y="-72.9885" z="286.954"/>
 					<rotation yaw="0" pitch="0" roll="153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_021" group="group_port_barrage " tags="medium shield hittable ">
+			<connection name="con_shieldgen_021" group="group_port_barrage " tags="medium shield hittable standard ">
 				<offset>
 					<position x="111.469" y="-72.9885" z="318.321"/>
 					<rotation yaw="0" pitch="0" roll="153.679"/>
 				</offset>
 			</connection>
 			<!-- M Battery 05 Starboard Barrage-->
-			<connection name="con_turret_013" group="group_starboard_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_013" group="group_starboard_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-111.469" y="-72.9885" z="347.528"/>
 					<rotation yaw="0" pitch="0" roll="-153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group_starboard_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_014" group="group_starboard_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-111.469" y="-72.9885" z="258.085"/>
 					<rotation yaw="0" pitch="0" roll="-153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group_starboard_barrage " tags="turret medium standard hittable ">
+			<connection name="con_turret_015" group="group_starboard_barrage " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-111.286" y="-072.1928" z="148.543"/>
 					<rotation yaw="0" pitch="-2.5" roll="-153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_starboard_barrage " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_starboard_barrage " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-111.469" y="-72.9885" z="286.954"/>
 					<rotation yaw="0" pitch="0" roll="-153.679"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_022" group="group_starboard_barrage " tags="medium shield hittable ">
+			<connection name="con_shieldgen_022" group="group_starboard_barrage " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-111.469" y="-72.9885" z="318.321"/>
 					<rotation yaw="0" pitch="0" roll="-153.679"/>
 				</offset>
 			</connection>
 			<!-- L Engines -->
-			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-94.6647" y="1.2934" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="0" y="-4.5091" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-48.0267" y="-21.8656" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="48.0267" y="-21.8656" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="94.6647" y="1.2934" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_009" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_009" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="59.2066" y="29.8905" z="-291.537"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_010" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_010" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-59.2066" y="29.8905" z="-291.537"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_023" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_023" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="59.2066" y="29.8905" z="-352.236"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_024" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_024" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-59.2066" y="29.8905" z="-352.236"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_025" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_025" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="59.2066" y="29.8905" z="-411.928"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_026" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_026" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-59.2066" y="29.8905" z="-411.928"/>
 				</offset>

--- a/assets/units/size_l/ship_ter_l_shikoku.xml
+++ b/assets/units/size_l/ship_ter_l_shikoku.xml
@@ -229,25 +229,25 @@
 				</offset>
 			</connection>
 			<!-- L Shields -->
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-307.934"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/> 
 				</offset>
 			</connection> 
-			<connection name="con_shieldgenerator_l_02" tags="large shield ">
+			<connection name="con_shieldgenerator_l_02" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-307.934"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgenerator_l_03" tags="large shield ">
+			<!-- <connection name="con_shieldgenerator_l_03" tags="large shield standard">
 				<offset>
 					<position x="-77.7984" y="-41.5545" z="-402.129"/>
 					<rotation yaw="0" pitch="0" roll="-153.27"/>
 				</offset>
 			</connection>
-			 <connection name="con_shieldgenerator_l_04" tags="large shield ">
+			 <connection name="con_shieldgenerator_l_04" tags="large shield standard">
 				<offset>
 					<position x="77.7984" y="-41.5545" z="-402.129"/>
 					<rotation yaw="0" pitch="0" roll="153.27"/>

--- a/assets/units/size_l/ship_ter_l_shikoku.xml
+++ b/assets/units/size_l/ship_ter_l_shikoku.xml
@@ -254,385 +254,385 @@
 				</offset>
 			</connection>  -->
 			<!-- L Battery 01 -->
-			<!-- <connection name="con_turret_laser_l_05" group="group_keel_battery " tags="turret large standard terronly">
+			<!-- <connection name="con_turret_laser_l_05" group="group_keel_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-70.2227" z="309.185"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_turret_laser_l_06" group="group_keel_battery " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_06" group="group_keel_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-59.8808" z="72.1042"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_07" group="group_keel_battery " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_07" group="group_keel_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="-57.8808" z="-4.0867"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="9.2801" y="-70.2227" z="271.028"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_009" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_009" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-9.2801" y="-70.2227" z="271.028"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_010" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_010" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="9.2801" y="-59.8808" z="34.1948"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_keel_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_keel_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-9.2801" y="-59.8808" z="34.1948"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
 			<!-- L Battery 02 -->
-			<!-- <connection name="con_turret_laser_l_01" group="group_back_up_mid " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_01" group="group_back_up_mid " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="60.31" z="-121.998"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_001" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-25.7264" y="38.4537" z="-297.807"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="25.7264" y="38.4537" z="-297.807"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_018" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_018" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="64.1347" y="30" z="-381.648"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_019" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_019" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-64.1347" y="30" z="-381.648"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_020" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_020" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="64.1347" y="30" z="-410.45"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_021" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_021" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-64.1347" y="30" z="-410.45"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 03 -->
-			<connection name="con_turret_laser_l_02" group="group_front_up_mid " tags="turret large  standard  terronly">
+			<connection name="con_turret_laser_l_02" group="group_front_up_mid " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="49.919" z="-4.2492"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_03" group="group_front_up_mid " tags="turret large  standard  terronly">
+			<connection name="con_turret_laser_l_03" group="group_front_up_mid " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="60.31" z="-121.998"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group_front_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group_front_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.5282 " y="49.879" z="35.7941"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_015" group="group_front_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_015" group="group_front_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.5282 " y="49.879" z="35.7941"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_016" group="group_front_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_016" group="group_front_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.5282 " y="49.879" z="-49"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_017" group="group_front_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_017" group="group_front_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.5282 " y="49.879" z="-49"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 04 -->
-			<!-- <connection name="con_turret_laser_l_04" group="group_front_up_front " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_04" group="group_front_up_front " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="30" z="302.526"/>
 				</offset>
 			</connection> -->
-			<!-- <connection name="con_turret_laser_l_08" group="group_front_up_front " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_08" group="group_front_up_front " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="23.0198" z="425.39 "/>
 					<rotation yaw="0" pitch="-6.02671" roll="0"/>
 				</offset>
 			</connection> -->
-			<!-- <connection name="con_shieldgen_004" group="group_front_up_front " tags="medium shield hittable ">
+			<!-- <connection name="con_shieldgen_004" group="group_front_up_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.8365" y="38.4796" z="252.306"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_012" group="group_front_up_front " tags="medium shield hittable ">
+			<connection name="con_shieldgen_012" group="group_front_up_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.8365" y="38.4796" z="252.306"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_013" group="group_front_up_front " tags="medium shield hittable ">
+			<connection name="con_shieldgen_013" group="group_front_up_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="12.8365" y="30" z="347.367"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_014" group="group_front_up_front " tags="medium shield hittable ">
+			<connection name="con_shieldgen_014" group="group_front_up_front " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-12.8365" y="30" z="347.367"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
 			<!-- M Turret Defense 01 -->
-			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="61.3142" z="-241.984"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-51.4738" z="499.175"/>
 					<rotation yaw="0" pitch="7.62378" roll="180"/> 
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-2.2718" z="637.516"/>
 					<rotation yaw="0" pitch="-8" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="26.3438" y="49.9184" z="-227.435"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_034" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_034" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-26.3438" y="49.9184" z="-227.435"/>
 				</offset>
 			</connection>
 			<!-- M Turret Defense 02 -->
-			<connection name="con_turret_004" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_004" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="38.4537" z="-320.234"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_005" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-90.4281" z="-276.295"/>
 					<rotation yaw="0" pitch="180" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_010" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="11.4312" y="-66.0206" z="-438.659"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group_rear_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_011" group="group_rear_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-11.4312" y="-66.0206" z="-438.659"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group_rear_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group_rear_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="18.215 " y="38.4537" z="-317.139"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_022" group="group_rear_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_022" group="group_rear_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-18.215 " y="38.4537" z="-317.139"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_023" group="group_rear_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_023" group="group_rear_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="28.092" y="-66.0206" z="-438.714"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_024" group="group_rear_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_024" group="group_rear_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-28.092" y="-66.0206" z="-438.714"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Turret Defense 03 -->
-			<connection name="con_turret_006" group="group_fighter_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group_fighter_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="49.9184" z="-292.553"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_fighter_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_fighter_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="18.3111" z="558.581"/>
 					<rotation yaw="0" pitch="-3" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_fighter_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_fighter_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="64.4864" y="38.4537" z="-177.727"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_fighter_defense " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_fighter_defense " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-64.4864" y="38.4537" z="-177.727"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group_fighter_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group_fighter_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="28.2584" y="50.2917" z="-179.891"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_025" group="group_fighter_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_025" group="group_fighter_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-28.2584" y="50.2917" z="-179.891"/>
 				</offset>
 			</connection>
 			<!-- M Turret Array Top -->
-			<connection name="con_turret_012" group="group_array_top " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_012" group="group_array_top " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="59.1854" y="29.666 " z="247.433"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group_array_top " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_013" group="group_array_top " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-59.1854" y="29.666 " z="247.433"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group_array_top " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_014" group="group_array_top " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="59.1854" y="29.666 " z="147.185"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group_array_top " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_015" group="group_array_top " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-59.1854" y="29.666 " z="147.185"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_026" group="group_array_top " tags="medium shield hittable ">
+			<connection name="con_shieldgen_026" group="group_array_top " tags="medium shield hittable standard ">
 				<offset>
 					<position x="47.7423" y="29.666 " z="247.433"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_027" group="group_array_top " tags="medium shield hittable ">
+			<connection name="con_shieldgen_027" group="group_array_top " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-47.7423" y="29.666 " z="247.433"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_028" group="group_array_top " tags="medium shield hittable ">
+			<connection name="con_shieldgen_028" group="group_array_top " tags="medium shield hittable standard ">
 				<offset>
 					<position x="47.7423" y="29.666 " z="147.185"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_029" group="group_array_top " tags="medium shield hittable ">
+			<connection name="con_shieldgen_029" group="group_array_top " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-47.7423" y="29.666 " z="147.185"/>
 				</offset>
 			</connection>
 			<!-- M Turret Array Sides -->
-			<connection name="con_turret_016" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_016" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="260.581"/>
 					<rotation yaw="0" pitch="0" roll="153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_017" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_017" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="260.581"/>
 					<rotation yaw="0" pitch="0" roll="-153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_018" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_018" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="224.434"/>
 					<rotation yaw="180" pitch="0" roll="-153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_019" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_019" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="224.434"/>
 					<rotation yaw="-180" pitch="0" roll="153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_020" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_020" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="67.6671"/>
 					<rotation yaw="0" pitch="0" roll="153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_021" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_021" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="67.6671"/>
 					<rotation yaw="0" pitch="0" roll="-153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_022" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_022" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="31.5198"/>
 					<rotation yaw="180" pitch="0" roll="-153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_023" group="group_array_sides " tags="turret medium standard missile terronly hittable ">
+			<connection name="con_turret_023" group="group_array_sides " tags="turret medium standard missile terronly hittable combat">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="31.5198"/>
 					<rotation yaw="-180" pitch="0" roll="153.273"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_030" group="group_array_sides " tags="medium shield hittable ">
+			<connection name="con_shieldgen_030" group="group_array_sides " tags="medium shield hittable standard ">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="242.058"/>
 					<rotation yaw="90" pitch="-153.273" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_031" group="group_array_sides " tags="medium shield hittable ">
+			<connection name="con_shieldgen_031" group="group_array_sides " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="242.058"/>
 					<rotation yaw="-90" pitch="-153.273" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_032" group="group_array_sides " tags="medium shield hittable ">
+			<connection name="con_shieldgen_032" group="group_array_sides " tags="medium shield hittable standard ">
 				<offset>
 					<position x="79.7643" y="-25.2838" z="49.1441"/>
 					<rotation yaw="90" pitch="-153.273" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_033" group="group_array_sides " tags="medium shield hittable ">
+			<connection name="con_shieldgen_033" group="group_array_sides " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-79.7643" y="-25.2838" z="49.1441"/>
 					<rotation yaw="-90" pitch="-153.273" roll="0"/>
@@ -669,27 +669,27 @@
 				</offset>
 			</connection>
 			<!-- Engines -->
-			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-94.6647" y="1.2934" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="0" y="-4.5091" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-48.0267" y="-21.8656" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="48.0267" y="-21.8656" z="-442.586"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="94.6647" y="1.2934" z="-442.586"/>
 				</offset>

--- a/assets/units/size_m/ship_arg_m_bomber_01.xml
+++ b/assets/units/size_m/ship_arg_m_bomber_01.xml
@@ -18,8 +18,8 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right highpower </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right highpower combat</replace>
 
 </diff>
 <!-- <components>
@@ -1666,13 +1666,13 @@
 					<position x="6.000042E-03" y="8.450531" z="34.65281"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L02" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_L02" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-10.79143" y="0" z="-13.40924"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision symmetry symmetry_left">
+			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision symmetry symmetry_left combat">
 				<offset>
 					<position x="-10" y="0" z="36.0381"/>
 				</offset>
@@ -1682,25 +1682,25 @@
 					<position x="0" y="14.9281" z="-3.668688"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-10.79143" y="0" z="12.58174"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_R01" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_R01" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="10.79019" y="-9.536743E-07" z="12.58174"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_R02" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_R02" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="10.79019" y="-9.536743E-07" z="-13.40924"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon medium standard missile platformcollision symmetry symmetry_right">
+			<connection name="con_primaryweapon_02" tags="weapon medium standard missile platformcollision symmetry symmetry_right combat">
 				<offset>
 					<position x="10" y="0" z="36.0381"/>
 				</offset>

--- a/assets/units/size_m/ship_arg_m_bomber_01.xml
+++ b/assets/units/size_m/ship_arg_m_bomber_01.xml
@@ -1656,7 +1656,7 @@
 					<position x="0" y="14.9281" z="-1.206957"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_01" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="0" y="7.380809" z="-34.83206"/>
 				</offset>
@@ -1705,7 +1705,7 @@
 					<position x="10" y="0" z="36.0381"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_02" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="0" y="-7.409005" z="-34.83206"/>
 					<quaternion qx="2.843113E-15" qy="-2.384186E-07" qz="-1" qw="1.192488E-08"/>

--- a/assets/units/size_m/ship_arg_m_bomber_01.xml
+++ b/assets/units/size_m/ship_arg_m_bomber_01.xml
@@ -1631,7 +1631,7 @@
 					<quaternion qx="0.7071068" qy="3.823782E-08" qz="3.823782E-08" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium platformcollision ">
+			<connection name="con_engine_01" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="0" y="0" z="-40.36489"/>
 				</offset>

--- a/assets/units/size_m/ship_arg_m_bomber_02.xml
+++ b/assets/units/size_m/ship_arg_m_bomber_02.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right  </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right combat</replace>
 </diff>

--- a/assets/units/size_m/ship_arg_m_frigate_01.xml
+++ b/assets/units/size_m/ship_arg_m_frigate_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_left highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_right highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_left highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_right highpower combat</replace>
 </diff>

--- a/assets/units/size_m/ship_arg_m_miner_solid_01.xml
+++ b/assets/units/size_m/ship_arg_m_miner_solid_01.xml
@@ -7,5 +7,5 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining combat</replace>
 </diff>

--- a/assets/units/size_m/ship_par_m_corvette_01.xml
+++ b/assets/units/size_m/ship_par_m_corvette_01.xml
@@ -7,9 +7,9 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_1 highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags">weapon medium standard missile platformcollision symmetry symmetry_2 highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon medium standard missile platformcollision </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_05']/@tags">weapon medium standard missile platformcollision symmetry symmetry_1  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_2 </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_1 highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags">weapon medium standard missile platformcollision symmetry symmetry_2 highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon medium standard missile platformcollision combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_05']/@tags">weapon medium standard missile platformcollision symmetry symmetry_1 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_2 combat</replace>
 </diff>

--- a/assets/units/size_m/ship_par_m_frigate_01.xml
+++ b/assets/units/size_m/ship_par_m_frigate_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
 </diff>

--- a/assets/units/size_m/ship_par_m_miner_solid_01.xml
+++ b/assets/units/size_m/ship_par_m_miner_solid_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining combat</replace>
 
 </diff>

--- a/assets/units/size_m/ship_tel_m_bomber_01.xml
+++ b/assets/units/size_m/ship_tel_m_bomber_01.xml
@@ -1813,7 +1813,7 @@
 					<quaternion qx="-0.7071068" qy="3.823782E-08" qz="-3.823782E-08" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium platformcollision ">
+			<connection name="con_engine_02" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="8.648455E-03" y="-2.337425" z="-44.7169"/>
 				</offset>
@@ -1899,7 +1899,7 @@
 					<quaternion qx="-2.084587E-07" qy="1.157083E-07" qz="0.4853156" qw="-0.874339"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium platformcollision ">
+			<connection name="con_engine_01" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="8.648455E-03" y="6.710684" z="-44.7169"/>
 				</offset>

--- a/assets/units/size_m/ship_tel_m_bomber_01.xml
+++ b/assets/units/size_m/ship_tel_m_bomber_01.xml
@@ -1833,7 +1833,7 @@
 					<position x="0.089653" y="8.740403" z="50.87145"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_01" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="-9.146002" y="8.243243" z="-32.9408"/>
 					<quaternion qx="-2.095921E-07" qy="-1.136423E-07" qz="-0.4766503" qw="-0.879093"/>
@@ -1855,7 +1855,7 @@
 					<quaternion qx="-0" qy="-0" qz="-0.4999999" qw="-0.8660254"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_02" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="5.116427E-02" y="12.32381" z="-31.04067"/>
 				</offset>
@@ -1893,7 +1893,7 @@
 					<quaternion qx="-0" qy="-0" qz="0.5000001" qw="-0.8660253"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_003" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_003" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="9.35384" y="7.912618" z="-32.9408"/>
 					<quaternion qx="-2.084587E-07" qy="1.157083E-07" qz="0.4853156" qw="-0.874339"/>

--- a/assets/units/size_m/ship_tel_m_bomber_01.xml
+++ b/assets/units/size_m/ship_tel_m_bomber_01.xml
@@ -18,8 +18,8 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_002']/@tags"> weapon medium standard missile platformcollision highpower </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_002']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
 </diff>
 
 <!-- 
@@ -1839,7 +1839,7 @@
 					<quaternion qx="-2.095921E-07" qy="-1.136423E-07" qz="-0.4766503" qw="-0.879093"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision ">
+			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision combat">
 				<offset>
 					<position x="-13.85948" y="-7.780499" z="13.57349"/>
 				</offset>
@@ -1849,7 +1849,7 @@
 					<position x="0" y="15.81977" z="-2.780109"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-10.46507" y="5.854039" z="3.193537"/>
 					<quaternion qx="-0" qy="-0" qz="-0.4999999" qw="-0.8660254"/>
@@ -1870,24 +1870,24 @@
 					<position x="0" y="-10.53959" z="12.48533"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_002" tags="weapon medium standard missile platformcollision ">
+			<connection name="con_primaryweapon_002" tags="weapon medium standard missile platformcollision combat">
 				<offset>
 					<position x="14.1182" y="-7.780499" z="13.57349"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L02" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_L02" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-10.46507" y="5.854039" z="-15.20008"/>
 					<quaternion qx="-0" qy="-0" qz="-0.4999999" qw="-0.8660254"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L03" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_L03" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="10.40647" y="5.854039" z="3.193537"/>
 					<quaternion qx="-0" qy="-0" qz="0.5000001" qw="-0.8660253"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L04" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_L04" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="10.55575" y="5.854039" z="-15.20008"/>
 					<quaternion qx="-0" qy="-0" qz="0.5000001" qw="-0.8660253"/>

--- a/assets/units/size_m/ship_tel_m_frigate_01.xml
+++ b/assets/units/size_m/ship_tel_m_frigate_01.xml
@@ -14,6 +14,6 @@
 </add>
 
 
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags">weapon medium standard missile platformcollision highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags">weapon medium standard missile platformcollision highpower </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags">weapon medium standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags">weapon medium standard missile platformcollision highpower combat</replace>
 </diff>

--- a/assets/units/size_m/ship_tel_m_frigate_01.xml
+++ b/assets/units/size_m/ship_tel_m_frigate_01.xml
@@ -5,7 +5,7 @@
    <position x="0" y="0" z="0"/>
   </offset>
  </connection>
- <connection name="con_shield_inside" tags="medium shield unhittable platformcollision">
+ <connection name="con_shield_inside" tags="medium shield unhittable platformcollision standard">
   <offset>
     <position x="0" y="0" z="-20"/>
   </offset>

--- a/assets/units/size_m/ship_tel_m_miner_solid_01.xml
+++ b/assets/units/size_m/ship_tel_m_miner_solid_01.xml
@@ -7,5 +7,5 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard missile mining combat</replace>
 </diff>

--- a/assets/units/size_m/ship_tel_m_trans_container_03.xml
+++ b/assets/units/size_m/ship_tel_m_trans_container_03.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 <!-- turrets -->
-      <connection name="con_turret_L04" tags="turret medium standard missile platformcollision unhittable">
+      <connection name="con_turret_L04" tags="turret medium standard missile platformcollision unhittable combat">
         <offset>
           <position x="0" y="-5" z="-70.29195"/>
           <rotation yaw="180" pitch="0" roll="180"/>
@@ -16,6 +16,6 @@
 
 </add>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile platformcollision highpower </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_m/ship_xen_m_fighter_01.xml
+++ b/assets/units/size_m/ship_xen_m_fighter_01.xml
@@ -214,7 +214,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium platformcollision ">
+			<connection name="con_engine_01" tags="engine medium platformcollision standard">
 				<offset/>
 			</connection>
 			<connection name="con_dockpos" tags="dockpos ">

--- a/assets/units/size_m/ship_xen_m_fighter_01.xml
+++ b/assets/units/size_m/ship_xen_m_fighter_01.xml
@@ -227,7 +227,7 @@
 					<position x="0" y="27.04314" z="0.3386583"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_01" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="0" y="2.685177" z="-16.21134"/>
 					<quaternion qx="0.7071067" qy="1.152023E-07" qz="-0.7071068" qw="-8.43217E-09"/>
@@ -253,7 +253,7 @@
 					<position x="8.858631" y="-15.5734" z="62.53819"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_02" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="0" y="-10.20299" z="5.856657"/>
 					<quaternion qx="0.8433915" qy="7.373163E-08" qz="-4.697221E-08" qw="-0.5372996"/>

--- a/assets/units/size_m/ship_xen_m_fighter_01.xml
+++ b/assets/units/size_m/ship_xen_m_fighter_01.xml
@@ -3,7 +3,7 @@
 <add sel="//components/component[@name='ship_xen_m_fighter_01']/connections">
 
 <!-- new connections -->
-			<connection name="con_primaryweapon_03" tags="weapon medium standard missile platformcollision">
+			<connection name="con_primaryweapon_03" tags="weapon medium standard missile platformcollision combat">
 				<offset>
 					<position x="0" y="-15.5671" z="62.53819"/>
 				</offset>
@@ -238,7 +238,7 @@
 					<position x="6.000042E-03" y="27.05147" z="2.826822"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon medium standard platformcollision symmetry symmetry_left">
+			<connection name="con_primaryweapon_01" tags="weapon medium standard platformcollision symmetry symmetry_left combat">
 				<offset>
 					<position x="-8.844477" y="-15.5671" z="62.53819"/>
 				</offset>
@@ -248,7 +248,7 @@
 					<position x="0" y="26.94825" z="-2.672149"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon medium standard platformcollision symmetry symmetry_right">
+			<connection name="con_primaryweapon_02" tags="weapon medium standard platformcollision symmetry symmetry_right combat">
 				<offset>
 					<position x="8.858631" y="-15.5734" z="62.53819"/>
 				</offset>
@@ -270,13 +270,13 @@
 					<quaternion qx="-0.9238796" qy="-0" qz="-0" qw="-0.3826834"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_top" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_top" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="0" y="21.06926" z="20.55078"/>
 					<quaternion qx="-1.311008E-08" qy="-0.9848077" qz="-0.1736483" qw="7.435091E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bottom" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_bottom" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="0" y="-19.03532" z="20.17132"/>
 					<quaternion qx="-7.54979E-08" qy="1.629207E-07" qz="-1" qw="-1.230017E-14"/>

--- a/assets/units/size_s/ship_arg_s_fighter_01.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_01.xml
@@ -8,8 +8,8 @@
 				</offset>
 			</connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision missile symmetry symmetry_right highpower standard</replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left  </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision missile symmetry symmetry_right highpower standard combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left combat</replace>
 </diff>
 <!-- 
 <components>
@@ -1768,12 +1768,12 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right">
+			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right combat">
 				<offset>
 					<position x="9.849237" y="-0.2442537" z="3.862374"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left">
+			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left combat">
 				<offset>
 					<position x="-9.864611" y="-0.2714961" z="3.862374"/>
 				</offset>

--- a/assets/units/size_s/ship_arg_s_fighter_01.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_01.xml
@@ -1751,7 +1751,7 @@
 					<part ref="thruster_ship_s_01.anim_thruster_001" name="anim_thruster_00"/>
 				</parts>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="-5.084418E-03" y="0.8125332" z="-0.5541968"/>
 					<quaternion qx="8.715575E-02" qy="7.619399E-09" qz="-8.70901E-08" qw="-0.9961947"/>

--- a/assets/units/size_s/ship_arg_s_fighter_01.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_01.xml
@@ -647,7 +647,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision " parent="detail_xl_rotator_l">
+			<connection name="con_engine_01" tags="engine small platformcollision " parent="detail_xl_rotator_l standard">
 				<offset>
 					<position x="-2.591923" y="5.281436E-02" z="1.910157"/>
 				</offset>
@@ -700,7 +700,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision " parent="detail_xl_rotator_r">
+			<connection name="con_engine_02" tags="engine small platformcollision " parent="detail_xl_rotator_r standard">
 				<offset>
 					<position x="2.704676" y="5.281377E-02" z="1.910159"/>
 				</offset>

--- a/assets/units/size_s/ship_arg_s_fighter_02.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_02.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_fighter_03.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_03.xml
@@ -8,11 +8,11 @@
  </connection>
 </add>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_002']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_003']/@tags"> weapon small standard missile platformcollision symmetry symmetry_right symmetry_bottom  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_004']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left symmetry_bottom </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags"> weapon small standard missile platformcollision symmetry symmetry_right symmetry_top </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left symmetry_top </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_002']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_003']/@tags"> weapon small standard missile platformcollision symmetry symmetry_right symmetry_bottom combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_004']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left symmetry_bottom combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags"> weapon small standard missile platformcollision symmetry symmetry_right symmetry_top combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags"> weapon small standard missile platformcollision symmetry symmetry_left symmetry_top combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_fighter_04.xml
+++ b/assets/units/size_s/ship_arg_s_fighter_04.xml
@@ -7,9 +7,9 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_002']/@tags"> weapon small standard missile platformcollision highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags"> weapon small standard missile platformcollision  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags"> weapon small standard missile platformcollision  </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_002']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags"> weapon small standard missile platformcollision combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_heavyfighter_02.xml
+++ b/assets/units/size_s/ship_arg_s_heavyfighter_02.xml
@@ -7,10 +7,10 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision missile highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision missile highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags">weapon small platformcollision standard missile </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon small platformcollision standard missile </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision missile highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision missile highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags">weapon small platformcollision standard missile combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon small platformcollision standard missile combat</replace>
 
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_miner_solid_01.xml
+++ b/assets/units/size_s/ship_arg_s_miner_solid_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon']/@tags">weapon small standard missile mining platformcollision </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon']/@tags">weapon small standard missile mining platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_scout_01.xml
+++ b/assets/units/size_s/ship_arg_s_scout_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_trans_container_01.xml
+++ b/assets/units/size_s/ship_arg_s_trans_container_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon']/@tags"> weapon small standard missile platformcollision </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_arg_s_trans_container_02.xml
+++ b/assets/units/size_s/ship_arg_s_trans_container_02.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags">weapon small standard missile platformcollision symmetry symmetry_right symmetry_top </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags">weapon small standard missile platformcollision symmetry symmetry_left symmetry_top  </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_005']/@tags">weapon small standard missile platformcollision symmetry symmetry_right symmetry_top combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_006']/@tags">weapon small standard missile platformcollision symmetry symmetry_left symmetry_top combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_gen_s_fighter_01.xml
+++ b/assets/units/size_s/ship_gen_s_fighter_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_gen_s_fightingdrone_01.xml
+++ b/assets/units/size_s/ship_gen_s_fightingdrone_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon small standard missile </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon small standard missile combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_gen_s_lasertower_01.xml
+++ b/assets/units/size_s/ship_gen_s_lasertower_01.xml
@@ -1,5 +1,5 @@
 <diff>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_001']/@tags">weapon small standard </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_001']/@tags">weapon small standard combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_fighter_01.xml
+++ b/assets/units/size_s/ship_par_s_fighter_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_fighter_02.xml
+++ b/assets/units/size_s/ship_par_s_fighter_02.xml
@@ -7,8 +7,8 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile mining platformcollision symmetry highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile mining platformcollision symmetry_1 symmetry_right highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile mining platformcollision symmetry_1 symmetry_left highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile mining platformcollision symmetry highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile mining platformcollision symmetry_1 symmetry_right highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile mining platformcollision symmetry_1 symmetry_left highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_heavyfighter_01.xml
+++ b/assets/units/size_s/ship_par_s_heavyfighter_01.xml
@@ -7,9 +7,9 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision  </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small standard missile platformcollision highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision   </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile platformcollision highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_miner_solid_01.xml
+++ b/assets/units/size_s/ship_par_s_miner_solid_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_right </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_left </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_left combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_scout_01.xml
+++ b/assets/units/size_s/ship_par_s_scout_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_par_s_trans_container_01.xml
+++ b/assets/units/size_s/ship_par_s_trans_container_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_right </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_left </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_left combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_fighter_01.xml
+++ b/assets/units/size_s/ship_tel_s_fighter_01.xml
@@ -7,7 +7,7 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_fighter_02.xml
+++ b/assets/units/size_s/ship_tel_s_fighter_02.xml
@@ -1309,12 +1309,12 @@
 					<position x="-7.827505E-03" y="-6.499243E-02" z="-5.287531"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-6.185094" y="-0.4903351" z="-4.137647"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="6.184999" y="-0.4903351" z="-4.137647"/>
 				</offset>

--- a/assets/units/size_s/ship_tel_s_fighter_02.xml
+++ b/assets/units/size_s/ship_tel_s_fighter_02.xml
@@ -15,9 +15,9 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision symmetry </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision symmetry_1 symmetry_left highpower</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile platformcollision symmetry_1 symmetry_right highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision symmetry combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision symmetry_1 symmetry_left highpower combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small standard missile platformcollision symmetry_1 symmetry_right highpower combat</replace>
 
 
 </diff>
@@ -1246,7 +1246,7 @@
 					<position x="0.2251749" y="5.037749" z="-7.740235"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small standard missile platformcollision symmetry_1 symmetry_left">
+			<connection name="con_weapon_02" tags="weapon small standard missile platformcollision symmetry_1 symmetry_left combat">
 				<offset>
 					<position x="-7.025583" y="-0.5493716" z="13.38157"/>
 				</offset>
@@ -1257,7 +1257,7 @@
 					<quaternion qx="-2.527779E-04" qy="-9.653279E-06" qz="-3.816116E-02" qw="-0.9992716"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small standard missile platformcollision symmetry_1 symmetry_right ">
+			<connection name="con_weapon_03" tags="weapon small standard missile platformcollision symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="7.026" y="-0.5493716" z="13.38157"/>
 				</offset>
@@ -1319,7 +1319,7 @@
 					<position x="6.184999" y="-0.4903351" z="-4.137647"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small standard missile platformcollision symmetry ">
+			<connection name="con_weapon_01" tags="weapon small standard missile platformcollision symmetry combat">
 				<offset>
 					<position x="4.43089E-03" y="-1.441262" z="7.660055"/>
 				</offset>

--- a/assets/units/size_s/ship_tel_s_fighter_02.xml
+++ b/assets/units/size_s/ship_tel_s_fighter_02.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 <add sel="//components/component/connections">
-	<connection name="con_shield_03" tags="small shield unhittable ">
+	<connection name="con_shield_03" tags="small shield unhittable standard">
 		<offset>
 			<position x="0" y="2.9134" z="-3.8563"/>
 		</offset>
@@ -1213,7 +1213,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="-8.420899" y="-6.916785E-02" z="10.49892"/>
 					<quaternion qx="2.511101E-04" qy="-9.589843E-06" qz="3.816335E-02" qw="-0.9992715"/>
@@ -1251,7 +1251,7 @@
 					<position x="-7.025583" y="-0.5493716" z="13.38157"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="8.421" y="-6.916785E-02" z="10.49892"/>
 					<quaternion qx="-2.527779E-04" qy="-9.653279E-06" qz="-3.816116E-02" qw="-0.9992716"/>

--- a/assets/units/size_s/ship_tel_s_miner_solid_01.xml
+++ b/assets/units/size_s/ship_tel_s_miner_solid_01.xml
@@ -8,6 +8,6 @@
   </offset>
  </connection>
  </add>
-<replace sel="//components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile mining platformcollision  </replace>
+<replace sel="//components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile mining platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_scout_01.xml
+++ b/assets/units/size_s/ship_tel_s_scout_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_scout_02.xml
+++ b/assets/units/size_s/ship_tel_s_scout_02.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small missile platformcollision highpower</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small missile platformcollision highpower combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_trans_container_01.xml
+++ b/assets/units/size_s/ship_tel_s_trans_container_01.xml
@@ -7,6 +7,6 @@
   </offset>
  </connection>
 </add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 </diff>

--- a/assets/units/size_s/ship_tel_s_trans_container_02.xml
+++ b/assets/units/size_s/ship_tel_s_trans_container_02.xml
@@ -7,8 +7,8 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small standard missile platformcollision combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small standard missile platformcollision combat</replace>
 
 	</diff>
 	

--- a/assets/units/size_s/ship_xen_s_fighter_02.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_02.xml
@@ -141,13 +141,13 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-5.590139" y="-6.188423" z="-11.054"/>
 					<quaternion qx="-4.176006E-07" qy="-5.329213E-07" qz="-0.906308" qw="-0.4226179"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="5.660837" y="-6.027495" z="-11.054"/>
 					<quaternion qx="1.080403E-07" qy="-5.038E-08" qz="-0.9063079" qw="0.4226181"/>
@@ -189,13 +189,13 @@
 					<position x="0.03255" y="9.336396" z="0.1571398"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" tags="engine small platformcollision ">
+			<connection name="con_engine_03" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-5.590139" y="5.496387" z="-11.054"/>
 					<quaternion qx="-5.329213E-07" qy="-4.176007E-07" qz="-0.4226184" qw="-0.9063078"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" tags="engine small platformcollision ">
+			<connection name="con_engine_04" tags="engine small platformcollision standard">
 				<offset>
 					<position x="5.815237" y="5.434033" z="-11.054"/>
 					<quaternion qx="-1.870628E-08" qy="4.028787E-08" qz="0.4226184" qw="-0.9063078"/>

--- a/assets/units/size_s/ship_xen_s_fighter_02.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_02.xml
@@ -9,14 +9,14 @@
 			</connection>
 			</add>
 <add sel="//components/component[@name='ship_xen_s_fighter_02']/connections">
-<connection name="con_primaryweapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right">
+<connection name="con_primaryweapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right combat">
 				<offset>
 					<position x="1.457059" y="0.321408" z="2.980415"/>
 				</offset>
 			</connection>
 			</add>
 <add sel="//components/component[@name='ship_xen_s_fighter_02']/connections">
-<connection name="con_primaryweapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left">
+<connection name="con_primaryweapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left combat">
 				<offset>
 					<position x="-1.503397" y="0.3225303" z="2.980414"/>
 				</offset>
@@ -159,12 +159,12 @@
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right">
+			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right combat">
 				<offset>
 					<position x="1.457059" y="0.321408" z="2.980415"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left">
+			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left combat">
 				<offset>
 					<position x="-1.503397" y="0.3225303" z="2.980414"/>
 				</offset>

--- a/assets/units/size_s/ship_xen_s_fighter_02.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_02.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff> 
 <add sel="//components/component[@name='ship_xen_s_fighter_02']/connections">
-<connection name="con_shield_02" tags="small shield unhittable ">
+<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-4.161448" z="-5.325171"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>
@@ -153,7 +153,7 @@
 					<quaternion qx="1.080403E-07" qy="-5.038E-08" qz="-0.9063079" qw="0.4226181"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-4.161448" z="-5.325171"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>

--- a/assets/units/size_s/ship_xen_s_fighter_lx.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_lx.xml
@@ -136,22 +136,22 @@
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard  symmetry symmetry_right">
+			<connection name="con_primaryweapon_01" tags="weapon small platformcollision standard  symmetry symmetry_right combat">
 				<offset>
 					<position x="1.457059" y="0.321408" z="2.980415"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard  symmetry symmetry_left">
+			<connection name="con_primaryweapon_02" tags="weapon small platformcollision standard  symmetry symmetry_left combat">
 				<offset>
 					<position x="-1.503397" y="0.3225303" z="2.980414"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_03" tags="weapon small platformcollision standard  symmetry symmetry_right">
+			<connection name="con_primaryweapon_03" tags="weapon small platformcollision standard  symmetry symmetry_right combat">
 				<offset>
 					<position x="1.457059" y="0.321408" z="2.980415"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_04" tags="weapon small platformcollision standard  symmetry symmetry_left">
+			<connection name="con_primaryweapon_04" tags="weapon small platformcollision standard  symmetry symmetry_left combat">
 				<offset>
 					<position x="-1.503397" y="0.3225303" z="2.980414"/>
 				</offset>

--- a/assets/units/size_s/ship_xen_s_fighter_lx.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_lx.xml
@@ -106,13 +106,13 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-5.590139" y="-6.188423" z="-11.054"/>
 					<quaternion qx="-4.176006E-07" qy="-5.329213E-07" qz="-0.906308" qw="-0.4226179"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="5.660837" y="-6.027495" z="-11.054"/>
 					<quaternion qx="1.080403E-07" qy="-5.038E-08" qz="-0.9063079" qw="0.4226181"/>
@@ -181,13 +181,13 @@
 					<position x="0.03255" y="9.336396" z="0.1571398"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" tags="engine small platformcollision ">
+			<connection name="con_engine_03" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-5.590139" y="5.496387" z="-11.054"/>
 					<quaternion qx="-5.329213E-07" qy="-4.176007E-07" qz="-0.4226184" qw="-0.9063078"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" tags="engine small platformcollision ">
+			<connection name="con_engine_04" tags="engine small platformcollision standard">
 				<offset>
 					<position x="5.815237" y="5.434033" z="-11.054"/>
 					<quaternion qx="-1.870628E-08" qy="4.028787E-08" qz="0.4226184" qw="-0.9063078"/>

--- a/assets/units/size_s/ship_xen_s_fighter_lx.xml
+++ b/assets/units/size_s/ship_xen_s_fighter_lx.xml
@@ -118,19 +118,19 @@
 					<quaternion qx="1.080403E-07" qy="-5.038E-08" qz="-0.9063079" qw="0.4226181"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-4.161448" z="-5.325171"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-4.161448" z="-5.325171"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_03" tags="small shield unhittable ">
+			<connection name="con_shield_03" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-4.161448" z="-5.325171"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="-6.600237E-15" qw="-7.54979E-08"/>

--- a/assets/units/size_xl/ship_arg_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_arg_xl_battleship_01.xml
@@ -741,37 +741,37 @@
 					<position x="-0.6052592" y="189.8951" z="-264.8389"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_back_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group_back_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-399.9172"/>
 					<quaternion qx="-0.7874227" qy="0.6164135" qz="2.30803E-07" qw="1.694395E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_002" group="group_back_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_002" group="group_back_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-439.1863"/>
 					<quaternion qx="-0.7874225" qy="0.6164137" qz="2.308028E-07" qw="1.694392E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_front_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group_front_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-76.13345" y="-107.998" z="905.142"/>
 					<quaternion qx="-0.6217118" qy="0.3368597" qz="-0.6217117" qw="-0.3368598"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_004" group="group_front_mid_left  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_004" group="group_front_mid_left  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-403.2272" y="15.53617" z="784.7994"/>
 					<quaternion qx="-0.4999999" qy="0.5" qz="-0.5" qw="-0.4999999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group_front_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group_front_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-446.6298" y="10.92819" z="464.6917"/>
 					<quaternion qx="-0.4640962" qy="0.5334929" qz="-0.4640962" qw="-0.5334929"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group_back_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group_back_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-477.2667"/>
 					<quaternion qx="-0.7874225" qy="0.6164135" qz="1.867702E-08" qw="-8.730964E-08"/>
@@ -782,37 +782,37 @@
 					<position x="-149.4115" y="-0.1187109" z="-518.0576"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="446.5946" y="10.90806" z="464.6917"/>
 					<quaternion qx="-0.4615709" qy="-0.5356793" qz="0.4615707" qw="-0.5356795"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_005" group="group_front_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_005" group="group_front_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="403.5192" y="15.59064" z="785.3893"/>
 					<quaternion qx="0.5" qy="0.5" qz="-0.4999999" qw="0.4999999"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_003" group="group_back_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_003" group="group_back_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="272.4523" y="14.64255" z="-440.5278"/>
 					<quaternion qx="-1.760706E-07" qy="1.139378E-07" qz="0.7886185" qw="-0.6148827"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="75.58228" y="-108.84" z="905.2043"/>
 					<quaternion qx="0.6211228" qy="0.3379445" qz="-0.6211228" qw="0.3379444"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group_back_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group_back_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="272.4523" y="14.64255" z="-478.6445"/>
 					<quaternion qx="2.656776E-07" qy="-2.80866E-07" qz="0.7886183" qw="-0.614883"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_back_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group_back_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="272.4523" y="14.64253" z="-401.234"/>
 					<quaternion qx="-2.569645E-07" qy="2.003543E-07" qz="0.7886183" qw="-0.6148831"/>
@@ -922,7 +922,7 @@
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_006" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_006" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="42.61111" z="-616.2017"/>
 					<quaternion qx="-0.7070858" qy="5.472347E-03" qz="0.7070854" qw="-5.472451E-03"/>
@@ -952,235 +952,235 @@
  			</connection>
 <!--=================================================================EDITS BY BLACKSCORP81=================================================================-->
 <!--Turrets LARGE front_up_mid-->
-			<connection name="con_turret_fumL01" group="group_front_up_middle_large " tags="turret large standard highpower argonly ">
+			<connection name="con_turret_fumL01" group="group_front_up_middle_large " tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="0" y="115" z="906"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fumL02" group="group_front_up_middle_large " tags="turret large standard highpower argonly">
+			<connection name="con_turret_fumL02" group="group_front_up_middle_large " tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="0" y="140" z="680"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_fumL01" group="group_front_up_middle_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_fumL01" group="group_front_up_middle_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="122" z="800"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE center_down_mid_B-->
-			<connection name="con_turret_cdmBL01" group="group_center_down_mid_b_large " tags="turret large standard ">
+			<connection name="con_turret_cdmBL01" group="group_center_down_mid_b_large " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-90" z="60"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_cdmBL02" group="group_center_down_mid_b_large " tags="turret large standard ">
+			<connection name="con_turret_cdmBL02" group="group_center_down_mid_b_large " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-90" z="-65"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_cdmBL01" group="group_center_down_mid_b_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_cdmBL01" group="group_center_down_mid_b_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="-35" z="-295"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE center_down_mid_F-->
-			<connection name="con_turret_cdmFL01" group="group_center_down_mid_f_large " tags="turret large standard ">
+			<connection name="con_turret_cdmFL01" group="group_center_down_mid_f_large " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-90" z="186"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_cdmFL02" group="group_center_down_mid_f_large " tags="turret large standard ">
+			<connection name="con_turret_cdmFL02" group="group_center_down_mid_f_large " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-90" z="311"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_cdmFL01" group="group_center_down_mid_f_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_cdmFL01" group="group_center_down_mid_f_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="-18.5" z="380"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_mid_mid-->
-			<!-- <connection name="con_turret_fmmM01" group="group_front_mid_mid " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_fmmM01" group="group_front_mid_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-120" z="905"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fmmM02" group="group_front_mid_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fmmM02" group="group_front_mid_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-115" z="820"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fmmM01" group="group_front_mid_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fmmM01" group="group_front_mid_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-100" z="600"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection> -->
 <!--Turrets MEDIUM front_left_right-->
-			<connection name="con_turret_flrM01" group="group_front_left_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_flrM01" group="group_front_left_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="75.58228" y="-108.84" z="905.2043"/>
 					<quaternion qx="0.6211228" qy="0.3379445" qz="-0.6211228" qw="0.3379444"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_flrM02" group="group_front_left_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_flrM02" group="group_front_left_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-76.13345" y="-107.998" z="905.142"/>
 					<quaternion qx="-0.6217118" qy="0.3368597" qz="-0.6217117" qw="-0.3368598"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_flrM01" group="group_front_left_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_flrM01" group="group_front_left_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-100" z="650"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_left_right-->
-			<!-- <connection name="con_turret_fmrM01" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_fmrM01" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="446.5946" y="10.90806" z="464.6917"/>
 					<quaternion qx="-0.4615709" qy="-0.5356793" qz="0.4615707" qw="-0.5356795"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fmrM02" group="group_front_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fmrM02" group="group_front_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="446.5946" y="10.90806" z="-220"/>
 					<quaternion qx="-0.4615709" qy="-0.5356793" qz="0.4615707" qw="-0.5356795"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fmrM01" group="group_front_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fmrM01" group="group_front_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="403.5192" y="15.59064" z="785.3893"/>
 					<quaternion qx="0.5" qy="0.5" qz="-0.4999999" qw="0.4999999"/>
 				</offset>
 			</connection> -->
 <!--Turrets MEDIUM back_up_mid-->
-			<connection name="con_turret_bumM01" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bumM01" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-40" y="113" z="-630"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bumM02" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bumM02" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="40" y="113" z="-630"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_bumM01" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bumM01" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="113" z="-630"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_mid_left-->
-			<!-- <connection name="con_turret_fmlM01" group="group_front_mid_left  " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_fmlM01" group="group_front_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-446.6298" y="10.92819" z="464.6917"/>
 					<quaternion qx="-0.4640962" qy="0.5334929" qz="-0.4640962" qw="-0.5334929"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fmlM02" group="group_front_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fmlM02" group="group_front_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-446.6298" y="10.92819" z="-220"/>
 					<quaternion qx="-0.4640962" qy="0.5334929" qz="-0.4640962" qw="-0.5334929"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fmlM01" group="group_front_mid_left  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fmlM01" group="group_front_mid_left  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-403.2272" y="15.53617" z="784.7994"/>
 					<quaternion qx="-0.4999999" qy="0.5" qz="-0.5" qw="-0.4999999"/>
 				</offset>
 			</connection> -->
 <!--Turrets MEDIUM back_mid_right-->		
-			<!-- <connection name="con_turret_bmrM01" group="group_back_mid_right " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_bmrM01" group="group_back_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="272.4523" y="14.64255" z="-478.6445"/>
 					<quaternion qx="2.656776E-07" qy="-2.80866E-07" qz="0.7886183" qw="-0.614883"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bmrM02" group="group_back_mid_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bmrM02" group="group_back_mid_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="272.4523" y="14.64253" z="-401.234"/>
 					<quaternion qx="-2.569645E-07" qy="2.003543E-07" qz="0.7886183" qw="-0.6148831"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_bmrM01" group="group_back_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bmrM01" group="group_back_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="272.4523" y="14.64255" z="-440.5278"/>
 					<quaternion qx="-1.760706E-07" qy="1.139378E-07" qz="0.7886185" qw="-0.6148827"/>
 				</offset>
 			</connection> -->
 <!--Turrets MEDIUM front_up_right-->
-			<connection name="con_turret_furM01" group="group_front_up_right_m " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_furM01" group="group_front_up_right_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="60" y="99" z="760"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_furM02" group="group_front_up_right_m " tags="turret medium standard missile hittable ">			
+			<connection name="con_turret_furM02" group="group_front_up_right_m " tags="turret medium standard missile hittable combat">			
 				<offset>
 					<position x="60" y="99" z="810"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_furM01" group="group_front_up_right_m " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_furM01" group="group_front_up_right_m " tags="medium shield hittable standard ">
 				<offset>
 					<position x="60" y="99" z="785"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_up_left-->
-			<connection name="con_turret_fulM01" group="group_front_up_left_m " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fulM01" group="group_front_up_left_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-60" y="99" z="760"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fulM02" group="group_front_up_left_m " tags="turret medium standard missile hittable ">			
+			<connection name="con_turret_fulM02" group="group_front_up_left_m " tags="turret medium standard missile hittable combat">			
 				<offset>
 					<position x="-60" y="99" z="810"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fulM01" group="group_front_up_left_m " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fulM01" group="group_front_up_left_m " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-60" y="99" z="785"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM back_mid_left-->
-			<!-- <connection name="con_turret_bmlM01" group="group_back_mid_left " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_bmlM01" group="group_back_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-477.2667"/>
 					<quaternion qx="-0.7874225" qy="0.6164135" qz="1.867702E-08" qw="-8.730964E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bmlM02" group="group_back_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bmlM02" group="group_back_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-399.9172"/>
 					<quaternion qx="-0.7874227" qy="0.6164135" qz="2.30803E-07" qw="1.694395E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_bmlM01" group="group_back_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bmlM01" group="group_back_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-270.1851" y="5.556479" z="-439.1863"/>
 					<quaternion qx="-0.7874225" qy="0.6164137" qz="2.308028E-07" qw="1.694392E-07"/>
 				</offset>
 			</connection> -->
 <!--Turrets MEDIUM back_down_mid-->
-			<!-- <connection name="con_turret_bdmM01" group="group_back_down_mid_m " tags="turret medium standard missile hittable ">
+			<!-- <connection name="con_turret_bdmM01" group="group_back_down_mid_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="150" y="-53" z="-400"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bdmM02" group="group_back_down_mid_m " tags="turret medium standard missile hittable ">			
+			<connection name="con_turret_bdmM02" group="group_back_down_mid_m " tags="turret medium standard missile hittable combat">			
 				<offset>
 					<position x="-150" y="-53" z="-400"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_bdmM01" group="group_back_down_mid_m " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bdmM01" group="group_back_down_mid_m " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-178" z="-350"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
@@ -1205,7 +1205,7 @@
 				</offset>
 			</connection>
 <!--Main Engines Back Mid Mid-->			
-			<connection name="con_shieldgen_m_bmmM01" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bmmM01" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="42.61111" z="-616.2017"/>
 					<quaternion qx="-0.7070858" qy="5.472347E-03" qz="0.7070854" qw="-5.472451E-03"/>

--- a/assets/units/size_xl/ship_arg_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_arg_xl_battleship_01.xml
@@ -823,7 +823,7 @@
 					<position x="149.9799" y="-0.1187109" z="-518.0418"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-19.2847" z="-216.1264"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
@@ -916,7 +916,7 @@
 					<position x="0" y="171.2857" z="-267.8827"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-19.2847" z="462.0961"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
@@ -1187,19 +1187,19 @@
 				</offset>
 			</connection> -->
 <!--Main Shield XL-->
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-19.2847" z="462.0961"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-19.2847" z="-216.1264"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_03" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_03" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="140" z="-220"/>
 				</offset>

--- a/assets/units/size_xl/ship_arg_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_arg_xl_battleship_01.xml
@@ -777,7 +777,7 @@
 					<quaternion qx="-0.7874225" qy="0.6164135" qz="1.867702E-08" qw="-8.730964E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine extralarge standard">
 				<offset>
 					<position x="-149.4115" y="-0.1187109" z="-518.0576"/>
 				</offset>
@@ -818,7 +818,7 @@
 					<quaternion qx="-2.569645E-07" qy="2.003543E-07" qz="0.7886183" qw="-0.6148831"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine extralarge">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine extralarge standard">
 				<offset>
 					<position x="149.9799" y="-0.1187109" z="-518.0418"/>
 				</offset>
@@ -1211,12 +1211,12 @@
 					<quaternion qx="-0.7070858" qy="5.472347E-03" qz="0.7070854" qw="-5.472451E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine extralarge standard">
 				<offset>
 					<position x="149.9799" y="-0.1187109" z="-518.0418"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine extralarge">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine extralarge standard">
 				<offset>
 					<position x="-149.4115" y="-0.1187109" z="-518.0576"/>
 				</offset>

--- a/assets/units/size_xl/ship_arg_xl_carrier_01.xml
+++ b/assets/units/size_xl/ship_arg_xl_carrier_01.xml
@@ -8,7 +8,7 @@
  </connection>
 </add>
 <replace sel="//components/component/connections/connection[@name='con_turret_l_001']">
-  <connection name="con_turret_l_001" group="group_up_mid_mid " tags="turret large standard highpower argonly missile ">
+  <connection name="con_turret_l_001" group="group_up_mid_mid " tags="turret large standard highpower argonly missile combat">
     <offset>
       <position x="0" y="159.3311" z="-242.3653"/>
     </offset>

--- a/assets/units/size_xl/ship_arg_xl_corona.xml
+++ b/assets/units/size_xl/ship_arg_xl_corona.xml
@@ -176,25 +176,25 @@
 					<position x="0" y="3.7948999999999997" z="-704.8727" />
 				</offset>
 			</connection>
-			<connection group="engine" name="con_shieldgen_m_engine_1" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_engine_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-28.2646" y="96.761" z="-713.8631" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.0" qy="-0.999999999999985" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="engine" name="con_shieldgen_m_engine_2" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_engine_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="28.7624" y="96.761" z="-713.8631" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.0" qy="-0.999999999999985" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="engine" name="con_shieldgen_m_engine_3" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_engine_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-22.312" y="-88.4453" z="-752.5765" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.999999999999985" qy="-0.0" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="engine" name="con_shieldgen_m_engine_4" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_engine_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="22.8097" y="-88.4453" z="-752.5765" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.999999999999985" qy="-0.0" qz="0.0" />
@@ -202,19 +202,19 @@
 			</connection>
 
 			<!-- XL SHIELDS -->
-			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="-267.9926" y="85.5825" z="130.578" />
 					<quaternion qw="-1.0" qx="0.0" qy="0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="268.24240000000003" y="85.5825" z="130.578" />
 					<quaternion qw="-1.0" qx="0.0" qy="0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_3" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_3" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="-97.85350000000001" z="-316.7866" />
 					<quaternion qw="-0.00026582679176584206" qx="-1.0000000477625651e-06" qy="-0.004223000201701313" qz="0.9999910477621353" />
@@ -222,97 +222,97 @@
 			</connection>
 
 			<!-- LARGE TURRETS -->
-			 <connection group="left-front-aloft" name="con_lm_turret_left-front-aloft_1" tags="turret large standard missile ">
+			 <connection group="left-front-aloft" name="con_lm_turret_left-front-aloft_1" tags="turret large standard missile combat">
 				<offset>
 					<position x="-397.6021" y="54.260200000000005" z="771.1744" />
 					<quaternion qw="-0.7280744925950654" qx="-0.045155800578209386" qy="0.683388583787443" qz="-0.029129546092791125" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_lm_turret_right-front-aloft_1" tags="turret large standard missile ">
+			<connection group="right-front-aloft" name="con_lm_turret_right-front-aloft_1" tags="turret large standard missile combat">
 				<offset>
 					<position x="397.6021" y="54.260200000000005" z="771.1744" />
 					<quaternion qw="-0.7280744925950654" qx="-0.045155800578209386" qy="-0.683388583787443" qz="0.029129546092791125" />
 				</offset>
 			</connection> 
-			<!-- <connection group="left-front-aloft" name="con_lm_turret_left-front-aloft_2" tags="turret large standard missile hittable">
+			<!-- <connection group="left-front-aloft" name="con_lm_turret_left-front-aloft_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-404.70160000000004" y="56.172999999999995" z="716.0748" />
 					<quaternion qw="-0.7280744925950654" qx="-0.045155800578209386" qy="0.683388583787443" qz="-0.029129546092791125" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_lm_turret_right-front-aloft_2" tags="turret large standard missile hittable">
+			<connection group="right-front-aloft" name="con_lm_turret_right-front-aloft_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="404.70160000000004" y="56.172999999999995" z="716.0748" />
 					<quaternion qw="-0.7280744925950654" qx="-0.045155800578209386" qy="-0.683388583787443" qz="0.029129546092791125" />
 				</offset>
 			</connection> -->
-			<!-- <connection group="left-front-deck" name="con_lm_turret_left-front-deck_2" tags="turret large standard missile hittable">
+			<!-- <connection group="left-front-deck" name="con_lm_turret_left-front-deck_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-404.073" y="-36.2385" z="716.5858000000001" />
 					<quaternion qw="-0.05456171892935074" qx="0.6764451086026809" qy="-0.07775602992543845" qz="-0.7303417239109483" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_lm_turret_right-front-deck_2" tags="turret large standard missile hittable">
+			<connection group="right-front-deck" name="con_lm_turret_right-front-deck_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="404.073" y="-36.2385" z="716.5858000000001" />
 					<quaternion qw="-0.05456171892935074" qx="0.6764451086026809" qy="0.07775602992543845" qz="0.7303417239109483" />
 				</offset>
 			</connection> -->
-			<connection group="left-front-deck" name="con_lm_turret_left-front-deck_1" tags="turret large standard missile ">
+			<connection group="left-front-deck" name="con_lm_turret_left-front-deck_1" tags="turret large standard missile combat">
 				<offset>
 					<position x="-397.4663" y="-32.6951" z="771.1056" />
 					<quaternion qw="-0.04594165041500491" qx="0.677315349669774" qy="-0.06976928188679578" qz="-0.7309346955534797" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_lm_turret_right-front-deck_1" tags="turret large standard missile ">
+			<connection group="right-front-deck" name="con_lm_turret_right-front-deck_1" tags="turret large standard missile combat">
 				<offset>
 					<position x="397.4663" y="-32.6951" z="771.1056" />
 					<quaternion qw="-0.04594165041500491" qx="0.677315349669774" qy="0.06976928188679578" qz="0.7309346955534797" />
 				</offset>
 			</connection>
-			<!-- <connection group="left-mid-aloft" name="con_lm_turret_left-mid-aloft_1" tags="turret large standard missile hittable">
+			<!-- <connection group="left-mid-aloft" name="con_lm_turret_left-mid-aloft_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-431.4044" y="71.0625" z="185.2128" />
 					<quaternion qw="-0.7064712760479074" qx="-0.029972152454453376" qy="0.7064712848189482" qz="-0.029972152454453376" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_lm_turret_right-mid-aloft_1" tags="turret large standard missile hittable">
+			<connection group="right-mid-aloft" name="con_lm_turret_right-mid-aloft_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="431.4044" y="71.0625" z="185.2128" />
 					<quaternion qw="-0.7064712760479074" qx="-0.029972152454453376" qy="-0.7064712848189482" qz="0.029972152454453376" />
 				</offset>
 			</connection> -->
-			<connection group="left-mid-aloft" name="con_lm_turret_left-mid-aloft_2" tags="turret large standard highpower argonly ">
+			<connection group="left-mid-aloft" name="con_lm_turret_left-mid-aloft_2" tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="-431.4044" y="71.0625" z="129.6229" />
 					<quaternion qw="-0.7064712760479074" qx="-0.029972152454453376" qy="0.7064712848189482" qz="-0.029972152454453376" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_lm_turret_right-mid-aloft_2" tags="turret large standard highpower argonly ">
+			<connection group="right-mid-aloft" name="con_lm_turret_right-mid-aloft_2" tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="431.4044" y="71.0625" z="129.6229" />
 					<quaternion qw="-0.7064712760479074" qx="-0.029972152454453376" qy="-0.7064712848189482" qz="0.029972152454453376" />
 				</offset>
 			</connection>
-			<!-- <connection group="left-mid-deck" name="con_lm_turret_left-mid-deck_1" tags="turret large standard missile hittable">
+			<!-- <connection group="left-mid-deck" name="con_lm_turret_left-mid-deck_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-431.28700000000003" y="-49.6327" z="185.6633" />
 					<quaternion qw="-0.03160056506530282" qx="0.7064002997844813" qy="-0.031601221753973376" qz="-0.7064002997844813" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_lm_turret_right-mid-deck_1" tags="turret large standard missile hittable">
+			<connection group="right-mid-deck" name="con_lm_turret_right-mid-deck_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="431.28700000000003" y="-49.6327" z="185.6633" />
 					<quaternion qw="-0.03160056506530282" qx="0.7064002997844813" qy="0.031601221753973376" qz="0.7064002997844813" />
 				</offset>
 			</connection> -->
-			<connection group="left-mid-deck" name="con_lm_turret_left-mid-deck_2" tags="turret large standard highpower argonly ">
+			<connection group="left-mid-deck" name="con_lm_turret_left-mid-deck_2" tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="-431.28700000000003" y="-49.5095" z="129.1723" />
 					<quaternion qw="-0.03160056506530282" qx="0.7064002997844813" qy="-0.031601221753973376" qz="-0.7064002997844813" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_lm_turret_right-mid-deck_2" tags="turret large standard highpower argonly ">
+			<connection group="right-mid-deck" name="con_lm_turret_right-mid-deck_2" tags="turret large standard highpower argonly combat">
 				<offset>
 					<position x="431.28700000000003" y="-49.5095" z="129.1723" />
 					<quaternion qw="-0.03160056506530282" qx="0.7064002997844813" qy="0.031601221753973376" qz="0.7064002997844813" />
@@ -320,241 +320,241 @@
 			</connection>
 
 			<!-- MEDIUM SHIELDS FOR LARGE TURRETS -->
-			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_1" tags="medium shield hittable">
+			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-385.1494" y="67.1806" z="776.1650000000001" />
 					<quaternion qw="-0.7223128211364261" qx="-0.0855059169102088" qy="0.6802271244696259" qz="-0.09079639712601986" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_1" tags="medium shield hittable">
+			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="385.1494" y="67.1806" z="776.1650000000001" />
 					<quaternion qw="-0.7223128211364261" qx="-0.0855059169102088" qy="-0.6802271244696259" qz="0.09079639712601986" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_2" tags="medium shield hittable">
+			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-385.9452" y="66.9773" z="762.4911" />
 					<quaternion qw="-0.7223128211364261" qx="-0.0855059169102088" qy="0.6802271244696259" qz="-0.09079639712601986" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_2" tags="medium shield hittable">
+			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="385.9452" y="66.9773" z="762.4911" />
 					<quaternion qw="-0.7223128211364261" qx="-0.0855059169102088" qy="-0.6802271244696259" qz="0.09079639712601986" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_3" tags="medium shield hittable">
+			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-415.17350000000005" y="59.716" z="778.0271" />
 					<quaternion qw="-0.6793803340573165" qx="0.083899636476157" qy="-0.7231462133958328" qz="-0.091993297291739" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_3" tags="medium shield hittable">
+			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="415.17350000000005" y="59.716" z="778.0271" />
 					<quaternion qw="-0.6793803340573165" qx="0.083899636476157" qy="0.7231462133958328" qz="0.091993297291739" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_4" tags="medium shield hittable">
+			<connection group="left-front-aloft" name="con_shieldgen_m_left-front-aloft_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-416.0562" y="59.851699999999994" z="764.3494999999999" />
 					<quaternion qw="-0.6792056736736749" qx="0.08253460717205251" qy="-0.7233031378819261" qz="-0.09327519605234753" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_4" tags="medium shield hittable">
+			<connection group="right-front-aloft" name="con_shieldgen_m_right-front-aloft_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="416.0562" y="59.851699999999994" z="764.3494999999999" />
 					<quaternion qw="-0.6792056736736749" qx="0.08253460717205251" qy="0.7233031378819261" qz="0.09327519605234753" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_2" tags="medium shield hittable">
+			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-414.69399999999996" y="-36.363800000000005" z="778.0353" />
 					<quaternion qw="-0.11045299952436043" qx="-0.7202938642176695" qy="0.07829103962592651" qz="-0.6803288889799849" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_2" tags="medium shield hittable">
+			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="414.69399999999996" y="-36.363800000000005" z="778.0353" />
 					<quaternion qw="-0.11045299952436043" qx="-0.7202938642176695" qy="-0.07829103962592651" qz="0.6803288889799849" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_3" tags="medium shield hittable">
+			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-415.5439" y="-36.8776" z="764.3729000000001" />
 					<quaternion qw="-0.11045299952436043" qx="-0.7202938642176695" qy="0.07829103962592651" qz="-0.6803288889799849" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_3" tags="medium shield hittable">
+			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="415.5439" y="-36.8776" z="764.3729000000001" />
 					<quaternion qw="-0.11045299952436043" qx="-0.7202938642176695" qy="-0.07829103962592651" qz="0.6803288889799849" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_1" tags="medium shield hittable">
+			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-385.0227" y="-45.2033" z="776.5201000000001" />
 					<quaternion qw="-0.0901662032808804" qx="0.6813370963423643" qy="-0.10485112275395121" qz="-0.7187879096026188" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_1" tags="medium shield hittable">
+			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="385.0227" y="-45.2033" z="776.5201000000001" />
 					<quaternion qw="-0.0901662032808804" qx="0.6813370963423643" qy="0.10485112275395121" qz="0.7187879096026188" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_4" tags="medium shield hittable">
+			<connection group="left-front-deck" name="con_shieldgen_m_left-front-deck_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-385.8047" y="-45.47" z="762.8386" />
 					<quaternion qw="-0.08880867181130556" qx="0.681143517589932" qy="-0.10613789082756289" qz="-0.7189515118469411" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_4" tags="medium shield hittable">
+			<connection group="right-front-deck" name="con_shieldgen_m_right-front-deck_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="385.8047" y="-45.47" z="762.8386" />
 					<quaternion qw="-0.08880867181130556" qx="0.681143517589932" qy="0.10613789082756289" qz="0.7189515118469411" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_1" tags="medium shield hittable">
+			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-414.6794" y="84.0976" z="135.5317" />
 					<quaternion qw="-0.699503737664612" qx="-0.0939258612976753" qy="0.7019959973648552" qz="-0.09525793014993361" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_1" tags="medium shield hittable">
+			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="414.6794" y="84.0976" z="135.5317" />
 					<quaternion qw="-0.699503737664612" qx="-0.0939258612976753" qy="-0.7019959973648552" qz="0.09525793014993361" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_2" tags="medium shield hittable">
+			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-414.6281" y="84.0785" z="121.83330000000001" />
 					<quaternion qw="-0.699503737664612" qx="-0.0939258612976753" qy="0.7019959973648552" qz="-0.09525793014993361" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_2" tags="medium shield hittable">
+			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="414.6281" y="84.0785" z="121.83330000000001" />
 					<quaternion qw="-0.699503737664612" qx="-0.0939258612976753" qy="-0.7019959973648552" qz="0.09525793014993361" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_3" tags="medium shield hittable">
+			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-444.616" y="76.0712" z="135.43449999999999" />
 					<quaternion qw="-0.701067809441528" qx="0.08857847016915688" qy="-0.7003808224680276" qz="-0.10062049844021924" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_3" tags="medium shield hittable">
+			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="444.616" y="76.0712" z="135.43449999999999" />
 					<quaternion qw="-0.701067809441528" qx="0.08857847016915688" qy="0.7003808224680276" qz="0.10062049844021924" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_4" tags="medium shield hittable">
+			<connection group="left-mid-aloft" name="con_shieldgen_m_left-mid-aloft_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-444.6575" y="76.3894" z="121.7316" />
 					<quaternion qw="-0.7008766749108833" qx="0.0872565419693588" qy="-0.7005466840988457" qz="-0.10194373863815956" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_4" tags="medium shield hittable">
+			<connection group="right-mid-aloft" name="con_shieldgen_m_right-mid-aloft_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="444.6575" y="76.3894" z="121.7316" />
 					<quaternion qw="-0.7008766749108833" qx="0.0872565419693588" qy="0.7005466840988457" qz="0.10194373863815956" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_1" tags="medium shield hittable">
+			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-442.76160000000004" y="-54.4748" z="135.61" />
 					<quaternion qw="-0.09223504499968792" qx="-0.7058733903272169" qy="0.08402033682817704" qz="-0.6972632474906056" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_1" tags="medium shield hittable">
+			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="442.76160000000004" y="-54.4748" z="135.61" />
 					<quaternion qw="-0.09223504499968792" qx="-0.7058733903272169" qy="-0.08402033682817704" qz="0.6972632474906056" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_2" tags="medium shield hittable">
+			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-442.9469" y="-54.611900000000006" z="121.91350000000001" />
 					<quaternion qw="-0.09223504499968792" qx="-0.7058733903272169" qy="0.08402033682817704" qz="-0.6972632474906056" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_2" tags="medium shield hittable">
+			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="442.9469" y="-54.611900000000006" z="121.91350000000001" />
 					<quaternion qw="-0.09223504499968792" qx="-0.7058733903272169" qy="-0.08402033682817704" qz="0.6972632474906056" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_3" tags="medium shield hittable">
+			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-412.8918" y="-62.7517" z="135.2869" />
 					<quaternion qw="-0.09578375700384871" qx="0.6980169666396496" qy="-0.08636210666892359" qz="-0.7043716154907971" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_3" tags="medium shield hittable">
+			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="412.8918" y="-62.7517" z="135.2869" />
 					<quaternion qw="-0.09578375700384871" qx="0.6980169666396496" qy="0.08636210666892359" qz="0.7043716154907971" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_4" tags="medium shield hittable">
+			<connection group="left-mid-deck" name="con_shieldgen_m_left-mid-deck_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-413.0129" y="-62.6402" z="121.5815" />
 					<quaternion qw="-0.0944533168591613" qx="0.6978579794554913" qy="-0.08768023555555976" qz="-0.704545944376606" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_4" tags="medium shield hittable">
+			<connection group="right-mid-deck" name="con_shieldgen_m_right-mid-deck_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="413.0129" y="-62.6402" z="121.5815" />
 					<quaternion qw="-0.0944533168591613" qx="0.6978579794554913" qy="0.08768023555555976" qz="0.704545944376606" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-aloft" name="con_shieldgen_m_left-mid-medium-aloft_1" tags="medium shield hittable">
+			<connection group="left-mid-medium-aloft" name="con_shieldgen_m_left-mid-medium-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-348.678" y="90.74680000000001" z="129.5118" />
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_shieldgen_m_right-mid-medium-aloft_1" tags="medium shield hittable">
+			<connection group="right-mid-medium-aloft" name="con_shieldgen_m_right-mid-medium-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="348.678" y="90.74680000000001" z="129.5118" />
 					<quaternion qw="-1.0" qx="-0.0" qy="-0.0" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-aloft" name="con_shieldgen_m_left-mid-medium-aloft_2" tags="medium shield hittable">
+			<connection group="left-mid-medium-aloft" name="con_shieldgen_m_left-mid-medium-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-362.21930000000003" y="90.74680000000001" z="129.5118" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.0" qy="-0.9999999999999466" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_shieldgen_m_right-mid-medium-aloft_2" tags="medium shield hittable">
+			<connection group="right-mid-medium-aloft" name="con_shieldgen_m_right-mid-medium-aloft_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="362.21930000000003" y="90.74680000000001" z="129.5118" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.0" qy="0.9999999999999466" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_shieldgen_m_left-mid-medium-deck_2" tags="medium shield hittable">
+			<connection group="left-mid-medium-deck" name="con_shieldgen_m_left-mid-medium-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-347.13" y="-77.6782" z="129.5118" />
 					<quaternion qw="-0.11766560388519191" qx="-0.0" qy="-0.0" qz="-0.9930532743324162" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_shieldgen_m_right-mid-medium-deck_2" tags="medium shield hittable">
+			<connection group="right-mid-medium-deck" name="con_shieldgen_m_right-mid-medium-deck_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="347.13" y="-77.6782" z="129.5118" />
 					<quaternion qw="-0.11766560388519191" qx="-0.0" qy="0.0" qz="0.9930532743324162" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_shieldgen_m_left-mid-medium-deck_1" tags="medium shield hittable">
+			<connection group="left-mid-medium-deck" name="con_shieldgen_m_left-mid-medium-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-333.9637" y="-80.84270000000001" z="129.5118" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.9930532242488069" qy="-0.1176660265710492" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_shieldgen_m_right-mid-medium-deck_1" tags="medium shield hittable">
+			<connection group="right-mid-medium-deck" name="con_shieldgen_m_right-mid-medium-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="333.9637" y="-80.84270000000001" z="129.5118" />
 					<quaternion qw="1.7320510330969933e-07" qx="0.9930532242488069" qy="0.1176660265710492" qz="0.0" />
@@ -562,205 +562,205 @@
 			</connection>
 
 			<!-- MEDIUM TURRETS + MEDIUM SHIELDS -->
-			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_1" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-354.065" y="91.0389" z="199.7208" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_1" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="354.065" y="91.0389" z="199.7208" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_2" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-354.065" y="91.0389" z="170.2358" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_2" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="354.065" y="91.0389" z="170.2358" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_3" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-354.065" y="91.0389" z="88.5544" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_3" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="354.065" y="91.0389" z="88.5544" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_4" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-aloft" name="con_mm_turret_left-mid-medium-aloft_4" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-354.065" y="91.0389" z="59.0694" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_4" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-aloft" name="con_mm_turret_right-mid-medium-aloft_4" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="354.065" y="91.0389" z="59.0694" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_1" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-339.0872" y="-79.6108" z="199.7208" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="-0.0841672552571976" qz="-0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_1" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="339.0872" y="-79.6108" z="199.7208" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="0.0841672552571976" qz="0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_2" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-339.0872" y="-79.6109" z="170.2358" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="-0.0841672552571976" qz="-0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_2" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="339.0872" y="-79.6109" z="170.2358" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="0.0841672552571976" qz="0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_3" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-339.0872" y="-79.6109" z="88.5544" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="-0.0841672552571976" qz="-0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_3" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="339.0872" y="-79.6109" z="88.5544" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="0.0841672552571976" qz="0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_4" tags="turret medium standard missile hittable">
+			<connection group="left-mid-medium-deck" name="con_mm_turret_left-mid-medium-deck_4" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-339.0872" y="-79.6109" z="59.0694" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="-0.0841672552571976" qz="-0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_4" tags="turret medium standard missile hittable">
+			<connection group="right-mid-medium-deck" name="con_mm_turret_right-mid-medium-deck_4" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="339.0872" y="-79.6109" z="59.0694" />
 					<quaternion qw="-0.08416713383860305" qx="0.7020796844817062" qy="0.0841672552571976" qz="0.7020796844817062" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-aloft" name="con_mm_turret_left-rear-medium-aloft_1" tags="turret medium standard missile hittable">
+			<connection group="left-rear-medium-aloft" name="con_mm_turret_left-rear-medium-aloft_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-468.8776" y="74.0296" z="-418.50849999999997" />
 					<quaternion qw="-0.6976594600354382" qx="-0.11520109370283711" qy="0.6976594397285835" qz="-0.11520109370283711" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-aloft" name="con_mm_turret_right-rear-medium-aloft_1" tags="turret medium standard missile hittable">
+			<connection group="right-rear-medium-aloft" name="con_mm_turret_right-rear-medium-aloft_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="468.8776" y="74.0296" z="-418.50849999999997" />
 					<quaternion qw="-0.6976594600354382" qx="-0.11520109370283711" qy="-0.6976594397285835" qz="0.11520109370283711" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-aloft" name="con_mm_turret_left-rear-medium-aloft_2" tags="turret medium standard missile hittable">
+			<connection group="left-rear-medium-aloft" name="con_mm_turret_left-rear-medium-aloft_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-468.8776" y="74.0296" z="-447.99350000000004" />
 					<quaternion qw="-0.6976594600354382" qx="-0.11520109370283711" qy="0.6976594397285835" qz="-0.11520109370283711" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-aloft" name="con_mm_turret_right-rear-medium-aloft_2" tags="turret medium standard missile hittable">
+			<connection group="right-rear-medium-aloft" name="con_mm_turret_right-rear-medium-aloft_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="468.8776" y="74.0296" z="-447.99350000000004" />
 					<quaternion qw="-0.6976594600354382" qx="-0.11520109370283711" qy="-0.6976594397285835" qz="0.11520109370283711" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-aloft" name="con_shieldgen_m_left-rear-medium-aloft_1" tags="medium shield hittable">
+			<connection group="left-rear-medium-aloft" name="con_shieldgen_m_left-rear-medium-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-447.37210000000005" y="79.9467" z="-433.3367" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.16035993592971523" qy="-0.9870586056301371" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-aloft" name="con_shieldgen_m_right-rear-medium-aloft_1" tags="medium shield hittable">
+			<connection group="right-rear-medium-aloft" name="con_shieldgen_m_right-rear-medium-aloft_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="447.37210000000005" y="79.9467" z="-433.3367" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.16035993592971523" qy="0.9870586056301371" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-deck" name="con_mm_turret_left-rear-medium-deck_1" tags="turret medium standard missile hittable">
+			<connection group="left-rear-medium-deck" name="con_mm_turret_left-rear-medium-deck_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-468.1805" y="-60.84929999999999" z="-418.50849999999997" />
 					<quaternion qw="-0.12710754898065643" qx="0.6923918553143159" qy="-0.14350446934358174" qz="-0.6955887125054188" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-deck" name="con_mm_turret_right-rear-medium-deck_1" tags="turret medium standard missile hittable">
+			<connection group="right-rear-medium-deck" name="con_mm_turret_right-rear-medium-deck_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="468.1805" y="-60.84929999999999" z="-418.50849999999997" />
 					<quaternion qw="-0.12710754898065643" qx="0.6923918553143159" qy="0.14350446934358174" qz="0.6955887125054188" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-deck" name="con_mm_turret_left-rear-medium-deck_2" tags="turret medium standard missile hittable">
+			<connection group="left-rear-medium-deck" name="con_mm_turret_left-rear-medium-deck_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-468.4116" y="-61.4538" z="-447.9869" />
 					<quaternion qw="-0.12737188286653345" qx="0.6927599409040964" qy="-0.1427269030897869" qz="-0.6953338039157781" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-deck" name="con_mm_turret_right-rear-medium-deck_2" tags="turret medium standard missile hittable">
+			<connection group="right-rear-medium-deck" name="con_mm_turret_right-rear-medium-deck_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="468.4116" y="-61.4538" z="-447.9869" />
 					<quaternion qw="-0.12737188286653345" qx="0.6927599409040964" qy="0.1427269030897869" qz="0.6953338039157781" />
 				</offset>
 			</connection>
-			<connection group="left-rear-medium-deck" name="con_shieldgen_m_left-rear-medium-deck_1" tags="medium shield hittable">
+			<connection group="left-rear-medium-deck" name="con_shieldgen_m_left-rear-medium-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-447.1901" y="-68.3208" z="-433.3367" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.9816955193788616" qy="-0.19045710076382158" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-medium-deck" name="con_shieldgen_m_right-rear-medium-deck_1" tags="medium shield hittable">
+			<connection group="right-rear-medium-deck" name="con_shieldgen_m_right-rear-medium-deck_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="447.1901" y="-68.3208" z="-433.3367" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.9816955193788616" qy="0.19045710076382158" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-engine-medium" name="con_mm_turret_left-engine-medium_1" tags="turret medium standard missile hittable">
+			<connection group="left-engine-medium" name="con_mm_turret_left-engine-medium_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-157.7312" y="49.8949" z="-640.0638" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="0.999999999999985" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-engine-medium" name="con_mm_turret_right-engine-medium_1" tags="turret medium standard missile hittable">
+			<connection group="right-engine-medium" name="con_mm_turret_right-engine-medium_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="157.7312" y="49.8949" z="-640.0638" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="-0.999999999999985" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-engine-medium" name="con_mm_turret_left-engine-medium_2" tags="turret medium standard missile hittable">
+			<connection group="left-engine-medium" name="con_mm_turret_left-engine-medium_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-157.7312" y="-40.9528" z="-640.0638" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.999999999999985" qy="0.0" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="right-engine-medium" name="con_mm_turret_right-engine-medium_2" tags="turret medium standard missile hittable">
+			<connection group="right-engine-medium" name="con_mm_turret_right-engine-medium_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="157.7312" y="-40.9528" z="-640.0638" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.999999999999985" qy="-0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="left-engine-medium" name="con_shieldgen_m_left-engine-medium_1" tags="medium shield hittable">
+			<connection group="left-engine-medium" name="con_shieldgen_m_left-engine-medium_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-159.9127" y="4.4848" z="-659.1566" />
 					<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-engine-medium" name="con_shieldgen_m_right-engine-medium_1" tags="medium shield hittable">
+			<connection group="right-engine-medium" name="con_shieldgen_m_right-engine-medium_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="159.9127" y="4.4848" z="-659.1566" />
 					<quaternion qw="-0.7071068967259818" qx="0.7071066656470943" qy="-0.0" qz="0.0" />
@@ -818,37 +818,37 @@
 			</connection>
 
 			<!-- MAIN BATTERIES-->
-			<!-- <connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 ">
+			<!-- <connection name="con_weapon_01" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="374.498" y="17.3222" z="1072.7399" />
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069" />
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_02" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="-374.498" y="17.3222" z="1072.7399" />
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069" />
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_03" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="233.57450000000003" y="-26.2374" z="1072.7399" />
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069" />
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_04" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="-233.57450000000003" y="-26.2374" z="1072.7399" />
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069" />
 				</offset>
 			</connection>
-			<connection name="con_weapon_05" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_05" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="233.57450000000003" y="29.173199999999998" z="1072.7399" />
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069" />
 				</offset>
 			</connection>
-			<connection name="con_weapon_06" tags="weapon large standard arg_destroyer_01 ">
+			<connection name="con_weapon_06" tags="weapon large standard arg_destroyer_01 combat">
 				<offset>
 					<position x="-233.57450000000003" y="29.173199999999998" z="1072.7399" />
 				</offset>

--- a/assets/units/size_xl/ship_arg_xl_corona.xml
+++ b/assets/units/size_xl/ship_arg_xl_corona.xml
@@ -171,7 +171,7 @@
 			</connection>
 
 			<!-- XL ENGINE + SHIELDS-->
-			<connection group="engine" name="con_engine_xl_engine_1" tags="engine extralarge">
+			<connection group="engine" name="con_engine_xl_engine_1" tags="engine extralarge standard">
 				<offset>
 					<position x="0" y="3.7948999999999997" z="-704.8727" />
 				</offset>

--- a/assets/units/size_xl/ship_par_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_01.xml
@@ -540,19 +540,19 @@
 				</offset>
 			</connection>
 <!--Main Shields XtraLARGE Center Down MID-->	
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="-115" y="-110.1" z="-358.4"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-110.1" z="-358.4"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_03" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_03" tags="extralarge shield standard">
 				<offset>
 					<position x="115" y="-110.1" z="-358.4"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/assets/units/size_xl/ship_par_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_01.xml
@@ -571,17 +571,17 @@
 					<quaternion qx="6.181724E-08" qy="0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_up_mid " tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_up_mid " tags="engine extralarge standard">
 				<offset>
 					<position x="-150.532" y="-14.4184" z="-858.3223"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_up_mid " tags="engine extralarge">
+			<connection name="con_engine_02" group="group_back_up_mid " tags="engine extralarge standard">
 				<offset>
 					<position x="0" y="-37.88454" z="-858.3223"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_up_mid " tags="engine extralarge">
+			<connection name="con_engine_03" group="group_back_up_mid " tags="engine extralarge standard">
 				<offset>
 					<position x="150.532" y="-14.4184" z="-858.3223"/>
 				</offset>

--- a/assets/units/size_xl/ship_par_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_01.xml
@@ -306,228 +306,228 @@
  			</connection>
 <!--=================================================================EDITS BY BLACKSCORP81=================================================================-->
 <!--Turrets MEDIUM Front Down MIDDLE-->
-			<connection name="con_turret_FDM01" group="group_front_down_middle " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_FDM01" group="group_front_down_middle " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-151.8" z="48.06415"/>
 					<quaternion qx="-1" qy="6.600236E-15" qz="-8.742278E-08" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_FDM02" group="group_front_down_middle " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_FDM02" group="group_front_down_middle " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-151.8" z="85.91931"/>
 					<quaternion qx="-7.54979E-08" qy="-7.54979E-08" qz="-1" qw="9.252647E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_FDM01" group="group_front_down_middle " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_FDM01" group="group_front_down_middle " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-4.336809E-19" y="-151.8" z="65.53563"/>
 					<quaternion qx="-1.509958E-07" qy="-1.509958E-07" qz="-1" qw="1.629207E-07"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Front Up MIDDLE-->
-			<connection name="con_turret_FUM01" group="group_front_up_middle " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_FUM01" group="group_front_up_middle " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-25" y="50.08132" z="726"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_FUM02" group="group_front_up_middle " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_FUM02" group="group_front_up_middle " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="25" y="50.08132" z="726"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_FUM03" group="group_front_up_middle " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_FUM03" group="group_front_up_middle " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="50.08132" z="726"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_FUM01" group="group_front_up_middle " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_FUM01" group="group_front_up_middle " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-25" y="50.08132" z="711"/>
 					<quaternion qx="6.181724E-08" qy="0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_FUM02" group="group_front_up_middle " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_FUM02" group="group_front_up_middle " tags="medium shield hittable standard ">
 				<offset>
 					<position x="25" y="50.08132" z="711"/>
 					<quaternion qx="6.181724E-08" qy="0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Back Up LEFT-->
-			<connection name="con_turret_BUL01" group="group_back_up_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUL01" group="group_back_up_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-425" y="31.4" z="-160.0141"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BUL02" group="group_back_up_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUL02" group="group_back_up_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-425" y="32" z="-133.2669"/>
 				</offset>
 			</connection>
-			<!--connection name="con_turret_BUL03" group="group_back_up_left " tags="turret medium standard missile hittable ">
+			<!--connection name="con_turret_BUL03" group="group_back_up_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-407" y="31.4" z="-160.0141"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BUL04" group="group_back_up_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUL04" group="group_back_up_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-407" y="32" z="-133.2669"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_BUL01" group="group_back_up_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_BUL01" group="group_back_up_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-407" y="32" z="-105"/>
 				</offset>
 			</connection-->
-			<connection name="con_shieldgen_m_BUL02" group="group_back_up_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_BUL02" group="group_back_up_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-418" y="33" z="-105"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Back Up RIGTH-->
-			<connection name="con_turret_BUR01" group="group_back_up_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUR01" group="group_back_up_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="425" y="31.4" z="-160.0141"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BUR02" group="group_back_up_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUR02" group="group_back_up_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="425" y="32" z="-133.2669"/>
 				</offset>
 			</connection>
-			<!--connection name="con_turret_BUR03" group="group_back_up_right " tags="turret medium standard missile hittable ">
+			<!--connection name="con_turret_BUR03" group="group_back_up_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="407" y="31.4" z="-160.0141"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BUR04" group="group_back_up_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_BUR04" group="group_back_up_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="407" y="32" z="-133.2669"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_BUR01" group="group_back_up_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_BUR01" group="group_back_up_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="407" y="32" z="-105"/>
 				</offset>
 			</connection-->
-			<connection name="con_shieldgen_m_BUR02" group="group_back_up_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_BUR02" group="group_back_up_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="418" y="33" z="-105"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Center Up MIDDLE-->
-			<connection name="con_turret_CUMM01" group="group_center_up_middle_medium " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_CUMM01" group="group_center_up_middle_medium " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="125" z="60"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_CUMM02" group="group_center_up_middle_medium " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_CUMM02" group="group_center_up_middle_medium " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="123" z="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_CUMM01" group="group_center_up_middle_medium " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_CUMM01" group="group_center_up_middle_medium " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="124" z="30"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE Center Up MIDDLE-->
-			<connection name="con_turret_CUML01" group="group_center_up_middle_large " tags="turret largestandard ">
+			<connection name="con_turret_CUML01" group="group_center_up_middle_large " tags="turret large standard combat">
 				<offset>
 					<position x="-60" y="52" z="-418"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_CUML02" group="group_center_up_middle_large " tags="turret large standard ">
+			<connection name="con_turret_CUML02" group="group_center_up_middle_large " tags="turret large standard combat">
 				<offset>
 					<position x="60" y="52" z="-418"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_CUML01" group="group_center_up_middle_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_CUML01" group="group_center_up_middle_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="52" z="-418"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_CUML03" group="group_center_up_middle_large " tags="turret large standard ">
+			<connection name="con_turret_CUML03" group="group_center_up_middle_large " tags="turret large standard combat">
 				<offset>
 					<position x="-130" y="55" z="-418"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_CUML04" group="group_center_up_middle_large " tags="turret large standard ">
+			<connection name="con_turret_CUML04" group="group_center_up_middle_large " tags="turret large standard combat">
 				<offset>
 					<position x="130" y="55" z="-418"/>
 				</offset>
 			</connection>
 
 <!--Turrets LARGE Back Down MIDDLE L-->
-			<connection name="con_turret_BDML01" group="group_back_down_middle_l " tags="turret large highpower paronly  standard ">
+			<connection name="con_turret_BDML01" group="group_back_down_middle_l " tags="turret large highpower paronly standard combat">
 				<offset>
 					<position x="-52" y="-130" z="-620"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BDML02" group="group_back_down_middle_l " tags="turret large highpower paronly  standard ">
+			<connection name="con_turret_BDML02" group="group_back_down_middle_l " tags="turret large highpower paronly standard combat">
 				<offset>
 					<position x="-52" y="-130" z="-520"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_BDML01" group="group_back_down_middle_l " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_BDML01" group="group_back_down_middle_l " tags="large shield hittable standard ">
 				<offset>
 					<position x="-25" y="-130" z="-690"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE Back Down MIDDLE R-->
-			<connection name="con_turret_BDMR01" group="group_back_down_middle_r " tags="turret large highpower paronly  standard ">
+			<connection name="con_turret_BDMR01" group="group_back_down_middle_r " tags="turret large highpower paronly standard combat">
 				<offset>
 					<position x="52" y="-130" z="-620"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_BDMR02" group="group_back_down_middle_r " tags="turret large highpower paronly  standard ">
+			<connection name="con_turret_BDMR02" group="group_back_down_middle_r " tags="turret large highpower paronly standard combat">
 				<offset>
 					<position x="52" y="-130" z="-520"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_BDMR01" group="group_back_down_middle_r " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_BDMR01" group="group_back_down_middle_r " tags="large shield hittable standard ">
 				<offset>
 					<position x="25" y="-130" z="-690"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Front Down Right-->
-			<connection name="con_turret_fdr01" group="group_front_down_right_m " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdr01" group="group_front_down_right_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="142.9605" y="-35" z="700"/>
 					<quaternion qx="-0.7029039" qy="-7.698051E-02" qz="-0.702904" qw="-7.698063E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fdr02" group="group_front_down_right_m " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdr02" group="group_front_down_right_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="142.9605" y="-24" z="740"/>
 					<quaternion qx="-0.7029039" qy="-7.698051E-02" qz="-0.702904" qw="-7.698063E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fdr01" group="group_front_down_right_m " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fdr01" group="group_front_down_right_m " tags="medium shield hittable standard ">
 				<offset>
 					<position x="142.9605" y="-30" z="720"/>
 					<quaternion qx="1.298226E-09" qy="-0.108867" qz="-0.9940563" qw="1.1854E-08"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM Front Down Left-->			
-			<connection name="con_turret_fdl01" group="group_front_down_left_m " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdl01" group="group_front_down_left_m " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-144.2267" y="-35" z="700"/>
 					<quaternion qx="-0.702904" qy="7.698058E-02" qz="0.702904" qw="-7.698048E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_fdl02" group="group_front_down_left_m  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdl02" group="group_front_down_left_m  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-144.2267" y="-24" z="740"/>
 					<quaternion qx="-0.702904" qy="7.698058E-02" qz="0.702904" qw="-7.698048E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fdl01" group="group_front_down_left_m " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fdl01" group="group_front_down_left_m " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-144.2267" y="-30" z="720"/>
 					<quaternion qx="-0.9940563" qy="1.66711E-07" qz="-2.57149E-08" qw="-0.108867"/>
@@ -559,13 +559,13 @@
 				</offset>
 			</connection>
 <!--Engines XtraLARGE Back Up MID-->
-			<connection name="con_shieldgen_m_engines01" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_engines01" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-13" y="59.5" z="-832.7117"/>
 					<quaternion qx="6.181724E-08" qy="0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_engines02" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_engines02" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="13" y="59.5" z="-832.7117"/>
 					<quaternion qx="6.181724E-08" qy="0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
@@ -586,22 +586,22 @@
 					<position x="150.532" y="-14.4184" z="-858.3223"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_ENGINES01" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ENGINES01" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-36" y="59.5" z="-832.7117"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_ENGINES02" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ENGINES02" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="36" y="59.5" z="-832.7117"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_ENGINES03" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ENGINES03" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-55" y="59.5" z="-832.7117"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_ENGINES04" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ENGINES04" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="55" y="59.5" z="-832.7117"/>
 				</offset>

--- a/assets/units/size_xl/ship_par_xl_battleship_02.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_02.xml
@@ -878,13 +878,13 @@
 					<quaternion qw="-0.7833090857553642" qx="-0.018879601917158546" qy="-0.6213024545961784" qz="0.007327804398915575" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_3" tags="shield medium hittable">
+			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_3" tags="shield medium hittable standard">
 				<offset>
 					<position x="-195.4859" y="-107.50249999999998" z="474.70090000000005" />
 					<quaternion qw="-1.7826794895597558e-05" qx="0.7071067809596389" qy="1.7999994424144434e-05" qz="-0.7071067809596389" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_3" tags="shield medium hittable">
+			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_3" tags="shield medium hittable standard">
 				<offset>
 					<position x="195.4859" y="-107.50249999999998" z="474.70090000000005" />
 					<quaternion qw="-1.7826794895597558e-05" qx="0.7071067809596389" qy="-1.7999994424144434e-05" qz="0.7071067809596389" />

--- a/assets/units/size_xl/ship_par_xl_battleship_02.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_02.xml
@@ -542,25 +542,25 @@
 					<position x="107.3576" y="-10.83" z="-1380.8414" />
 				</offset>
 			</connection>
-			<!-- <connection group="engine" name="con_shieldgen_m_left-engine_3" tags="medium shield hittable">
+			<!-- <connection group="engine" name="con_shieldgen_m_left-engine_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-11.5454" y="57.27139999999999" z="-1378.0962"/>
 					<quaternion qw="-8.267948966079389e-07" qx="0.00011199999289949837" qy="-0.9999669366047562" qz="0.008130999484516262"/>
 				</offset>
 			</connection> -->
-			<connection group="engine" name="con_shieldgen_m_left-engine_2" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_left-engine_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-11.5454" y="57.27139999999999" z="-1355.8247" />
 					<quaternion qw="-8.267948966079389e-07" qx="0.00011199999289949837" qy="-0.9999669366047562" qz="0.008130999484516262" />
 				</offset>
 			</connection>
-			<!-- <connection group="engine" name="con_shieldgen_m_right-engine_3" tags="medium shield hittable">
+			<!-- <connection group="engine" name="con_shieldgen_m_right-engine_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="11.5454" y="57.27139999999999" z="-1378.0962"/>
 					<quaternion qw="-8.267948966079389e-07" qx="0.00011199999289949837" qy="0.9999669366047562" qz="-0.008130999484516262"/>
 				</offset>
 			</connection> -->
-			<connection group="engine" name="con_shieldgen_m_right-engine_2" tags="medium shield hittable">
+			<connection group="engine" name="con_shieldgen_m_right-engine_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="11.5454" y="57.27139999999999" z="-1355.8247" />
 					<quaternion qw="-8.267948966079389e-07" qx="0.00011199999289949837" qy="0.9999669366047562" qz="-0.008130999484516262" />
@@ -568,13 +568,13 @@
 			</connection>
 
 			<!-- XL SHIELDS -->
-			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="-252.799" y="-58.0474" z="-557.4372000000001" />
 					<quaternion qw="-0.05830424306837294" qx="0.0" qy="0.04604353151179009" qz="-0.9972364857174786" />
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="252.799" y="-58.0474" z="-557.4372000000001" />
 					<quaternion qw="-0.06085819708947139" qx="0.005519747442902531" qy="-0.04635789335229025" qz="0.9970540396383355" />
@@ -582,27 +582,27 @@
 			</connection>
 
 			<!-- LARGE TURRETS -->
-			<connection group="middle-deck-largeturret" name="con_lm_turret_middle-rear-deck-largeturret_1" tags="turret large standard highpower paronly hittable">
+			<connection group="middle-deck-largeturret" name="con_lm_turret_middle-rear-deck-largeturret_1" tags="turret large standard highpower hittable paronly combat">
 				<offset>
 					<position x="-42.1782" y="-106.64229999999999" z="400"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
 
-			<connection group="middle-deck-largeturret" name="con_shieldgen_m_middle-deck-largeturret_1" tags="medium shield hittable">
+			<connection group="middle-deck-largeturret" name="con_shieldgen_m_middle-deck-largeturret_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-42.1782" y="-106.64229999999999" z="360"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
 
-			<connection group="left-rear-aloft-largeturret" name="con_lm_turret_left-rear-aloft-largeturret_2" tags="turret large standard highpower paronly hittable">
+			<connection group="left-rear-aloft-largeturret" name="con_lm_turret_left-rear-aloft-largeturret_2" tags="turret large standard highpower hittable paronly combat">
 				<offset>
 					<position x="-251.6493" y="62.327600000000004" z="-161.74530000000001" />
 					<quaternion qw="-0.7071068967259818" qx="-2.757715990053213e-05" qy="0.7071066641162085" qz="3.7476653198159046e-05" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-largeturret" name="con_lm_turret_right-rear-aloft-largeturret_2" tags="turret large standard highpower paronly hittable">
+			<connection group="right-rear-aloft-largeturret" name="con_lm_turret_right-rear-aloft-largeturret_2" tags="turret large standard highpower hittable paronly combat">
 				<offset>
 					<position x="251.6493" y="62.327600000000004" z="-161.74530000000001" />
 					<quaternion qw="-0.7071068967259818" qx="-2.757715990053213e-05" qy="-0.7071066641162085" qz="-3.7476653198159046e-05" />
@@ -614,91 +614,91 @@
 					<quaternion qw="-0.7071068967259818" qx="-2.757715990053213e-05" qy="0.7071066641162085" qz="3.7476653198159046e-05" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-largeturret" name="con_lm_turret_right-rear-aloft-largeturret_1" tags="turret large standard highpower paronly hittable">
+			<connection group="right-rear-aloft-largeturret" name="con_lm_turret_right-rear-aloft-largeturret_1" tags="turret large standard highpower hittable paronly combat">
 				<offset>
 					<position x="251.6493" y="62.3217" z="-96.99170000000001" />
 					<quaternion qw="-0.7071068967259818" qx="-2.757715990053213e-05" qy="-0.7071066641162085" qz="-3.7476653198159046e-05" />
 				</offset>
 			</connection>
-			<connection group="left-rear-aloft-largeturret" name="con_shieldgen_m_left-rear-aloft-largeturret_3" tags="medium shield hittable">
+			<connection group="left-rear-aloft-largeturret" name="con_shieldgen_m_left-rear-aloft-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-226.0161" y="62.1685" z="-204.4657" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="0.999999999999985" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-largeturret" name="con_shieldgen_m_right-rear-aloft-largeturret_3" tags="medium shield hittable">
+			<connection group="right-rear-aloft-largeturret" name="con_shieldgen_m_right-rear-aloft-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="226.0161" y="62.1685" z="-204.4657" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="-0.999999999999985" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-rear-aloft-largeturret" name="con_shieldgen_m_left-rear-aloft-largeturret_4" tags="medium shield hittable">
+			<connection group="left-rear-aloft-largeturret" name="con_shieldgen_m_left-rear-aloft-largeturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-225.98280000000003" y="62.1685" z="-227.01250000000002" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="0.999999999999985" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-largeturret" name="con_shieldgen_m_right-rear-aloft-largeturret_4" tags="medium shield hittable">
+			<connection group="right-rear-aloft-largeturret" name="con_shieldgen_m_right-rear-aloft-largeturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="225.98280000000003" y="62.1685" z="-227.01250000000002" />
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="-0.999999999999985" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-largeturret" name="con_lm_turret_left-front-aloft-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="left-front-aloft-largeturret" name="con_lm_turret_left-front-aloft-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-62.6225" y="57.6267" z="848.0618" />
 					<quaternion qw="-1" qx="0" qy="0" qz="0" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-largeturret" name="con_lm_turret_right-front-aloft-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="right-front-aloft-largeturret" name="con_lm_turret_right-front-aloft-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="62.6225" y="57.6267" z="848.0618" />
 					<quaternion qw="-1" qx="0" qy="0" qz="0" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-largeturret" name="con_shieldgen_m_left-front-aloft-largeturret_3" tags="medium shield hittable">
+			<connection group="left-front-aloft-largeturret" name="con_shieldgen_m_left-front-aloft-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-42.9551" y="58.412200000000006" z="802.4487" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-largeturret" name="con_shieldgen_m_right-front-aloft-largeturret_3" tags="medium shield hittable">
+			<connection group="right-front-aloft-largeturret" name="con_shieldgen_m_right-front-aloft-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="42.9551" y="58.412200000000006" z="802.4487" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-largeturret" name="con_shieldgen_m_left-front-aloft-largeturret_2" tags="medium shield hittable">
+			<connection group="left-front-aloft-largeturret" name="con_shieldgen_m_left-front-aloft-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-65.5019" y="58.412200000000006" z="802.4154" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-largeturret" name="con_shieldgen_m_right-front-aloft-largeturret_2" tags="medium shield hittable">
+			<connection group="right-front-aloft-largeturret" name="con_shieldgen_m_right-front-aloft-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="65.5019" y="58.412200000000006" z="802.4154" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-largeturret" name="con_lm_turret_left-front-deck-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="left-front-deck-largeturret" name="con_lm_turret_left-front-deck-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-219.6089" y="-107.4697" z="403.70990000000006" />
 					<quaternion qw="-1.332679489618442e-05" qx="0.6499537780113785" qy="1.0999996243003604e-05" qz="-0.7599737404345838" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-largeturret" name="con_shieldgen_m_left-front-deck-largeturret_3" tags="medium shield hittable">
+			<connection group="left-front-deck-largeturret" name="con_shieldgen_m_left-front-deck-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-207.0446" y="-107.50249999999998" z="363.5376" />
 					<quaternion qw="-1.9326794895326215e-05" qx="0.6427880567229872" qy="1.6000001411923986e-05" qz="-0.7660440675997436" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-largeturret" name="con_shieldgen_m_left-front-deck-largeturret_2" tags="medium shield hittable">
+			<connection group="left-front-deck-largeturret" name="con_shieldgen_m_left-front-deck-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-193.8169" y="-107.5064" z="438.55519999999996" />
 					<quaternion qw="-1.9326794895326215e-05" qx="0.6427880567229872" qy="1.6000001411923986e-05" qz="-0.7660440675997436" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck-largeturret" name="con_lm_turret_right-front-deck-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="right-front-deck-largeturret" name="con_lm_turret_right-front-deck-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="219.6089" y="-107.4697" z="403.70990000000006" />
 					<quaternion qw="-1.332679489618442e-05" qx="0.6499537780113785" qy="-1.0999996243003604e-05" qz="0.7599737404345838" />
@@ -706,25 +706,25 @@
 			</connection>
 
 
-			<connection group="right-front-deck-largeturret" name="con_shieldgen_m_right-front-deck-largeturret_3" tags="medium shield hittable">
+			<connection group="right-front-deck-largeturret" name="con_shieldgen_m_right-front-deck-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="207.0446" y="-107.50249999999998" z="363.5376" />
 					<quaternion qw="-1.9326794895326215e-05" qx="0.6427880567229872" qy="-1.6000001411923986e-05" qz="0.7660440675997436" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck-largeturret" name="con_shieldgen_m_right-front-deck-largeturret_2" tags="medium shield hittable">
+			<connection group="right-front-deck-largeturret" name="con_shieldgen_m_right-front-deck-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="193.8169" y="-107.5064" z="438.55519999999996" />
 					<quaternion qw="-1.9326794895326215e-05" qx="0.6427880567229872" qy="-1.6000001411923986e-05" qz="0.7660440675997436" />
 				</offset>
 			</connection>
-			<connection group="left-rear-deck-largeturret" name="con_lm_turret_left-rear-deck-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="left-rear-deck-largeturret" name="con_lm_turret_left-rear-deck-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-130.5378" y="-127.35929999999999" z="-417.6401" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="0.0" qz="-0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="right-rear-deck-largeturret" name="con_lm_turret_right-rear-deck-largeturret_1" tags="turret large standard missile hittable">
+			<connection group="right-rear-deck-largeturret" name="con_lm_turret_right-rear-deck-largeturret_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="130.5378" y="-127.35929999999999" z="-417.6401" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="-0.0" qz="0.7071067811865097" />
@@ -732,25 +732,25 @@
 			</connection>
 
 
-			<connection group="left-rear-deck-largeturret" name="con_shieldgen_m_left-rear-deck-largeturret_2" tags="medium shield hittable">
+			<connection group="left-rear-deck-largeturret" name="con_shieldgen_m_left-rear-deck-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-119.7201" y="-127.34" z="-380.5082" />
 					<quaternion qw="-3.632679488869548e-05" qx="-0.7071067806846304" qy="-9.999996898413258e-06" qz="0.7071067806846304" />
 				</offset>
 			</connection>
-			<connection group="right-rear-deck-largeturret" name="con_shieldgen_m_right-rear-deck-largeturret_2" tags="medium shield hittable">
+			<connection group="right-rear-deck-largeturret" name="con_shieldgen_m_right-rear-deck-largeturret_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="119.7201" y="-127.34" z="-380.5082" />
 					<quaternion qw="-3.632679488869548e-05" qx="-0.7071067806846304" qy="9.999996898413258e-06" qz="-0.7071067806846304" />
 				</offset>
 			</connection>
-			<connection group="left-rear-deck-largeturret" name="con_shieldgen_m_left-rear-deck-largeturret_3" tags="medium shield hittable">
+			<connection group="left-rear-deck-largeturret" name="con_shieldgen_m_left-rear-deck-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-143.3904" y="-127.34" z="-380.5082" />
 					<quaternion qw="-3.632679488869548e-05" qx="-0.7071067806846304" qy="-9.999996898413258e-06" qz="0.7071067806846304" />
 				</offset>
 			</connection>
-			<connection group="right-rear-deck-largeturret" name="con_shieldgen_m_right-rear-deck-largeturret_3" tags="medium shield hittable">
+			<connection group="right-rear-deck-largeturret" name="con_shieldgen_m_right-rear-deck-largeturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="143.3904" y="-127.34" z="-380.5082" />
 					<quaternion qw="-3.632679488869548e-05" qx="-0.7071067806846304" qy="9.999996898413258e-06" qz="-0.7071067806846304" />
@@ -758,121 +758,121 @@
 			</connection>
 
 			<!-- MEDIUM TURRETS -->
-			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-176.2799" y="65.1472" z="-227.163" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="176.2799" y="65.1472" z="-227.163" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-176.2799" y="65.1472" z="-245.0116" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="176.2799" y="65.1472" z="-245.0116" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_3" tags="turret medium standard missile hittable">
+			<connection group="left-mid-aloft-mediumturret" name="con_mm_turret_left-mid-aloft-mediumturret_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-176.2799" y="65.1472" z="-262.86019999999996" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_3" tags="turret medium standard missile hittable">
+			<connection group="right-mid-aloft-mediumturret" name="con_mm_turret_right-mid-aloft-mediumturret_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="176.2799" y="65.1472" z="-262.86019999999996" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-mediumturret" name="con_mm_turret_left-front-aloft-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="left-front-aloft-mediumturret" name="con_mm_turret_left-front-aloft-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-222.44410000000002" y="63.643899999999995" z="789.4801" />
 					<quaternion qw="-0.7914956623818895" qx="0.0003123102731591103" qy="0.6111747028554018" qz="-3.8504006279890314e-05" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-mediumturret" name="con_mm_turret_right-front-aloft-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="right-front-aloft-mediumturret" name="con_mm_turret_right-front-aloft-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="222.44410000000002" y="63.643899999999995" z="789.4801" />
 					<quaternion qw="-0.7914956623818895" qx="0.0003123102731591103" qy="-0.6111747028554018" qz="3.8504006279890314e-05" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-mediumturret" name="con_mm_turret_left-front-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="left-front-aloft-mediumturret" name="con_mm_turret_left-front-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-205.70420000000001" y="63.643899999999995" z="829.683" />
 					<quaternion qw="-0.855261273284669" qx="0.00030573618714520415" qy="0.5181969273647528" qz="-7.35839636857949e-05" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-mediumturret" name="con_mm_turret_right-front-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="right-front-aloft-mediumturret" name="con_mm_turret_right-front-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="205.70420000000001" y="63.643899999999995" z="829.683" />
 					<quaternion qw="-0.855261273284669" qx="0.00030573618714520415" qy="-0.5181969273647528" qz="7.35839636857949e-05" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_3" tags="turret medium standard missile hittable">
+			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-111.1628" y="-129.6479" z="-502.99940000000004" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="-0.0" qz="-0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_3" tags="turret medium standard missile hittable">
+			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_3" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="111.1628" y="-129.6479" z="-502.99940000000004" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="0.0" qz="0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-111.1628" y="-129.6479" z="-485.1509" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="-0.0" qz="-0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="111.1628" y="-129.6479" z="-485.1509" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="0.0" qz="0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="left-mid-deck-mediumturret" name="con_mm_turret_left-mid-deck-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-111.1628" y="-129.6479" z="-467.30229999999995" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="-0.0" qz="-0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="right-mid-deck-mediumturret" name="con_mm_turret_right-mid-deck-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="111.1628" y="-129.6479" z="-467.30229999999995" />
 					<quaternion qw="-3.2679489653813835e-07" qx="0.7071067811865097" qy="0.0" qz="0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="left-mid-aloft-mediumturret" name="con_shieldgen_m_left-mid-aloft-mediumturret_4" tags="medium shield hittable">
+			<connection group="left-mid-aloft-mediumturret" name="con_shieldgen_m_left-mid-aloft-mediumturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-176.1445" y="65.25030000000001" z="-298.299" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="0.7071066656470943" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-mid-aloft-mediumturret" name="con_shieldgen_m_right-mid-aloft-mediumturret_4" tags="medium shield hittable">
+			<connection group="right-mid-aloft-mediumturret" name="con_shieldgen_m_right-mid-aloft-mediumturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="176.1445" y="65.25030000000001" z="-298.299" />
 					<quaternion qw="-0.7071068967259818" qx="-0.0" qy="-0.7071066656470943" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-aloft-mediumturret" name="con_shieldgen_m_left-front-aloft-mediumturret_3" tags="medium shield hittable">
+			<connection group="left-front-aloft-mediumturret" name="con_shieldgen_m_left-front-aloft-mediumturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-227.83440000000002" y="59.2599" z="770.346" />
 					<quaternion qw="-0.7833090857553642" qx="-0.018879601917158546" qy="0.6213024545961784" qz="-0.007327804398915575" />
 				</offset>
 			</connection>
-			<connection group="right-front-aloft-mediumturret" name="con_shieldgen_m_right-front-aloft-mediumturret_3" tags="medium shield hittable">
+			<connection group="right-front-aloft-mediumturret" name="con_shieldgen_m_right-front-aloft-mediumturret_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="227.83440000000002" y="59.2599" z="770.346" />
 					<quaternion qw="-0.7833090857553642" qx="-0.018879601917158546" qy="-0.6213024545961784" qz="0.007327804398915575" />
@@ -890,61 +890,61 @@
 					<quaternion qw="-1.7826794895597558e-05" qx="0.7071067809596389" qy="-1.7999994424144434e-05" qz="0.7071067809596389" />
 				</offset>
 			</connection>
-			<connection group="left-mid-deck-mediumturret" name="con_shieldgen_m_left-mid-deck-mediumturret_4" tags="medium shield hittable">
+			<connection group="left-mid-deck-mediumturret" name="con_shieldgen_m_left-mid-deck-mediumturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="-111.1337" y="-129.8818" z="-538.3512999999999" />
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.7071067811865097" qy="0.0" qz="0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="right-mid-deck-mediumturret" name="con_shieldgen_m_right-mid-deck-mediumturret_4" tags="medium shield hittable">
+			<connection group="right-mid-deck-mediumturret" name="con_shieldgen_m_right-mid-deck-mediumturret_4" tags="medium shield hittable standard">
 				<offset>
 					<position x="111.1337" y="-129.8818" z="-538.3512999999999" />
 					<quaternion qw="-3.2679489653813835e-07" qx="-0.7071067811865097" qy="-0.0" qz="-0.7071067811865097" />
 				</offset>
 			</connection>
-			<connection group="left-rear-aloft-mediumturret" name="con_shieldgen_m_left-rear-aloft-mediumturret_1" tags="medium shield hittable">
+			<connection group="left-rear-aloft-mediumturret" name="con_shieldgen_m_left-rear-aloft-mediumturret_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-156.77030000000002" y="56.80349999999999" z="-1126.3686" />
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-mediumturret" name="con_shieldgen_m_right-rear-aloft-mediumturret_1" tags="medium shield hittable">
+			<connection group="right-rear-aloft-mediumturret" name="con_shieldgen_m_right-rear-aloft-mediumturret_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="156.77030000000002" y="56.80349999999999" z="-1126.3686" />
 					<quaternion qw="-1.0" qx="-0.0" qy="-0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="left-rear-aloft-mediumturret" name="con_mm_turret_left-rear-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="left-rear-aloft-mediumturret" name="con_mm_turret_left-rear-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-135.9565" y="59.28099999999999" z="-1126.3727" />
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0" />
 				</offset>
 			</connection>
-			<connection group="right-rear-aloft-mediumturret" name="con_mm_turret_right-rear-aloft-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="right-rear-aloft-mediumturret" name="con_mm_turret_right-rear-aloft-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="135.9565" y="59.28099999999999" z="-1126.3727" />
 					<quaternion qw="-1.0" qx="-0.0" qy="-0.0" qz="0.0" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-194.8014" y="-111.52519999999998" z="543.9211" />
 					<quaternion qw="-0.000279826791244645" qx="-0.7071067257836782" qy="-0.00027999989141591" qz="0.7071067257836782" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_1" tags="turret medium standard missile hittable">
+			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_1" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="194.8014" y="-111.52519999999998" z="543.9211" />
 					<quaternion qw="-0.000279826791244645" qx="-0.7071067257836782" qy="0.00027999989141591" qz="-0.7071067257836782" />
 				</offset>
 			</connection>
-			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="left-front-deck-mediumturret" name="con_mm_turret_left-front-deck-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-195.4437" y="-111.52519999999998" z="494.54459999999995" />
 					<quaternion qw="-0.000279826791244645" qx="-0.7071067257836782" qy="-0.00027999989141591" qz="0.7071067257836782" />
 				</offset>
 			</connection>
-			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_2" tags="turret medium standard missile hittable">
+			<connection group="right-front-deck-mediumturret" name="con_mm_turret_right-front-deck-mediumturret_2" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="195.4437" y="-111.52519999999998" z="494.54459999999995" />
 					<quaternion qw="-0.000279826791244645" qx="-0.7071067257836782" qy="0.00027999989141591" qz="-0.7071067257836782" />

--- a/assets/units/size_xl/ship_par_xl_battleship_02.xml
+++ b/assets/units/size_xl/ship_par_xl_battleship_02.xml
@@ -532,12 +532,12 @@
 			</connection>
 
 			<!-- ENGINES -->
-			<connection group="engine" name="con_engine_xl_left-engine_1" tags="engine extralarge">
+			<connection group="engine" name="con_engine_xl_left-engine_1" tags="engine extralarge standard">
 				<offset>
 					<position x="-107.3576" y="-10.83" z="-1380.8414" />
 				</offset>
 			</connection>
-			<connection group="engine" name="con_engine_xl_right-engine_1" tags="engine extralarge">
+			<connection group="engine" name="con_engine_xl_right-engine_1" tags="engine extralarge standard">
 				<offset>
 					<position x="107.3576" y="-10.83" z="-1380.8414" />
 				</offset>

--- a/assets/units/size_xl/ship_par_xl_carrier_01.xml
+++ b/assets/units/size_xl/ship_par_xl_carrier_01.xml
@@ -8,7 +8,7 @@
  </connection>
 </add>
 <replace sel="//components/component/connections/connection[@name='con_turret_laser_l_01']">
-  <connection name="con_turret_laser_l_01" group="group_mid_up_mid " tags="turret large standard highpower paronly missile ">
+  <connection name="con_turret_laser_l_01" group="group_mid_up_mid " tags="turret large standard highpower missile paronly combat">
     <offset>
       <position x="0" y="313.977" z="305.4196"/>
     </offset>

--- a/assets/units/size_xl/ship_par_xl_carrier_02.xml
+++ b/assets/units/size_xl/ship_par_xl_carrier_02.xml
@@ -9,7 +9,7 @@
 	 </connection>
 	</add>
 	<replace sel="//components/component/connections/connection[@name='con_turret_laser_l_01']">
-	  <connection name="con_turret_laser_l_01" group="group_mid_up_mid " tags="turret large standard highpower paronly missile ">
+	  <connection name="con_turret_laser_l_01" group="group_mid_up_mid " tags="turret large standard highpower missile paronly combat">
 		<offset>
 			<position x="-1.83039E-04" y="189.6119" z="-311.6255"/>
 		</offset>

--- a/assets/units/size_xl/ship_spl_xl_gharial.xml
+++ b/assets/units/size_xl/ship_spl_xl_gharial.xml
@@ -1072,73 +1072,73 @@
 					<quaternion qx="-2.135403E-07" qy="-0.7071068" qz="2.135403E-07" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group_mid_left_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_012" group="group_mid_left_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-84.62895" y="81.06121" z="-580.254"/>
 					<quaternion qx="8.636503E-08" qy="-1.202673E-02" qz="-8.846786E-08" qw="-0.9999276"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_001" group="group_mid_left_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_001" group="group_mid_left_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-84.63724" y="78.66224" z="-604.2128"/>
 					<quaternion qx="-1.051403E-09" qy="-1.202665E-02" qz="-8.741645E-08" qw="-0.9999276"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group_mid_left_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_011" group="group_mid_left_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-85.5145" y="82.19196" z="-628.1393"/>
 					<quaternion qx="8.636503E-08" qy="-1.202673E-02" qz="-8.846786E-08" qw="-0.9999276"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group_front_left_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group_front_left_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-74.66456" y="78.12961" z="-240.6301"/>
 					<quaternion qx="8.713378E-08" qy="-3.300423E-03" qz="-8.771084E-08" qw="-0.9999946"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_front_left_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_front_left_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-74.52192" y="77.21977" z="-192.6667"/>
 					<quaternion qx="8.713378E-08" qy="-3.300423E-03" qz="-8.771084E-08" qw="-0.9999946"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_008" group="group_front_left_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_008" group="group_front_left_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-73.77283" y="74.90222" z="-217.2418"/>
 					<quaternion qx="-2.885245E-10" qy="-3.300335E-03" qz="-8.742229E-08" qw="-0.9999945"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_front_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_front_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="74.52431" y="77.74277" z="-240.8435"/>
 					<quaternion qx="8.713378E-08" qy="-3.300423E-03" qz="-8.771084E-08" qw="-0.9999946"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_007" group="group_front_right_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_007" group="group_front_right_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="73.8651" y="75.09853" z="-217.2418"/>
 					<quaternion qx="-2.885245E-10" qy="-3.300335E-03" qz="-8.742229E-08" qw="-0.9999945"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_front_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_front_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="74.4249" y="77.21977" z="-192.7245"/>
 					<quaternion qx="8.713378E-08" qy="-3.300423E-03" qz="-8.771084E-08" qw="-0.9999946"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group_mid_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group_mid_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="85.45669" y="82.22072" z="-627.8929"/>
 					<quaternion qx="8.855864E-08" qy="1.307817E-02" qz="-8.627197E-08" qw="-0.9999145"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_006" group="group_mid_right_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_006" group="group_mid_right_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="84.2135" y="78.5666" z="-604.6384"/>
 					<quaternion qx="9.504618E-05" qy="1.325553E-03" qz="-1.04662E-03" qw="-0.9999986"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_mid_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group_mid_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="84.59755" y="81.27094" z="-579.9871"/>
 					<quaternion qx="8.813973E-08" qy="8.234808E-03" qz="-8.669991E-08" qw="-0.9999661"/>
@@ -1160,25 +1160,25 @@
 					<quaternion qx="-2.135403E-07" qy="-0.7071068" qz="2.135403E-07" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection group="group_back_mid_down" name="con_shieldgen_l_engine_1" tags="large shield hittable">
+			<connection group="group_back_mid_down" name="con_shieldgen_l_engine_1" tags="large shield hittable standard">
 				<offset>
 					<position x="-0.0" y="-124.36739999999999" z="-375.9895"/>
 					<quaternion qw="-0.02166413181575853" qx="0.9997653051554997" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group_back_mid_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group_back_mid_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-22.67358" y="23.01723" z="-1110.823"/>
 					<quaternion qx="-3.293199E-03" qy="6.639073E-02" qz="-0.9977883" qw="-2.182424E-04"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_back_mid_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group_back_mid_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="22.674" y="23.01723" z="-1110.823"/>
 					<quaternion qx="-3.293199E-03" qy="6.639073E-02" qz="-0.9977883" qw="-2.182424E-04"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_003" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_003" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-2.975464E-04" y="26.78661" z="-1139.859"/>
 					<quaternion qx="-3.29238E-03" qy="6.965759E-02" qz="-0.9975655" qw="-2.290186E-04"/>
@@ -1216,19 +1216,19 @@
 					<position x="0" y="77.54224" z="-840.3771"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-2.975464E-04" y="-106.1998" z="838.0213"/>
 					<quaternion qx="-3.300423E-03" qy="3.28738E-07" qz="-0.9999946" qw="8.770963E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_002" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_002" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-2.975464E-04" y="-105.8118" z="856.319"/>
 					<quaternion qx="-3.300335E-03" qy="-1.477033E-07" qz="-0.9999945" qw="9.978786E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-2.975464E-04" y="-105.8327" z="875.7616"/>
 					<quaternion qx="-3.300423E-03" qy="3.28738E-07" qz="-0.9999946" qw="8.770963E-07"/>
@@ -1262,487 +1262,487 @@
 			</connection>
 
 
-			<connection group="bottomnew" name="con_shieldgen_m_bottomnew_2" tags="medium shield hittable">
+			<connection group="bottomnew" name="con_shieldgen_m_bottomnew_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-12.5419" y="-137.33429999999998" z="-173.8654"/>
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="0.0" qz="-0.999999999999985"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-wing" name="con_shieldgen_m_left-mid-wing_2" tags="medium shield hittable">
+			<connection group="left-mid-wing" name="con_shieldgen_m_left-mid-wing_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-212.88680000000002" y="-60.5845" z="-485.1513"/>
 					<quaternion qw="-0.29648287012811386" qx="0.647469595525247" qy="-0.37043995255170403" qz="-0.5963684030399836"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-wing" name="con_shieldgen_m_right-mid-wing_2" tags="medium shield hittable">
+			<connection group="right-mid-wing" name="con_shieldgen_m_right-mid-wing_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="212.88680000000002" y="-60.5845" z="-485.1513"/>
 					<quaternion qw="-0.29648287012811386" qx="0.647469595525247" qy="0.37043995255170403" qz="0.5963684030399836"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-wing" name="con_shieldgen_m_left-mid-wing_1" tags="medium shield hittable">
+			<connection group="left-mid-wing" name="con_shieldgen_m_left-mid-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-212.6153" y="-62.1004" z="-495.6748"/>
 					<quaternion qw="-0.29668628653139445" qx="0.6475081209201166" qy="-0.3703821283473654" qz="-0.5962613183224172"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-wing" name="con_shieldgen_m_right-mid-wing_1" tags="medium shield hittable">
+			<connection group="right-mid-wing" name="con_shieldgen_m_right-mid-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="212.6153" y="-62.1004" z="-495.6748"/>
 					<quaternion qw="-0.29668628653139445" qx="0.6475081209201166" qy="0.3703821283473654" qz="0.5962613183224172"/>
 				</offset>
 			</connection>
-			<connection group="backnew" name="con_shieldgen_m_backnew_1" tags="medium shield hittable">
+			<connection group="backnew" name="con_shieldgen_m_backnew_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="24.5309" y="79.9376" z="-1161.5161"/>
 					<quaternion qw="-0.9994595672429439" qx="0.021223429884868018" qy="0.0010598681890177913" qz="0.025080194375068504"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_shieldgen_l_left-front_1" tags="large shield hittable">
+			<connection group="left-front" name="con_shieldgen_l_left-front_1" tags="large shield hittable standard">
 				<offset>
 					<position x="-49.2427" y="10.360700000000001" z="594.1548"/>
 					<quaternion qw="-0.6966564927139121" qx="-0.017376972288870047" qy="-0.02236221629990786" qz="-0.7168456621029236"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_shieldgen_l_right-front_1" tags="large shield hittable">
+			<connection group="right-front" name="con_shieldgen_l_right-front_1" tags="large shield hittable standard">
 				<offset>
 					<position x="49.2427" y="10.360700000000001" z="594.1548"/>
 					<quaternion qw="-0.6966564927139121" qx="-0.017376972288870047" qy="0.02236221629990786" qz="0.7168456621029236"/>
 				</offset>
 			</connection>
-			<connection group="left-nose" name="con_shieldgen_m_left-nose_1" tags="medium shield hittable">
+			<connection group="left-nose" name="con_shieldgen_m_left-nose_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-32.6419" y="-53.7321" z="932.398"/>
 					<quaternion qw="-0.5086416113405852" qx="0.47228617443244963" qy="-0.4771317600163493" qz="-0.5390498717526195"/>
 				</offset>
 			</connection>
-			<connection group="right-nose" name="con_shieldgen_m_right-nose_1" tags="medium shield hittable">
+			<connection group="right-nose" name="con_shieldgen_m_right-nose_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="32.6419" y="-53.7321" z="932.398"/>
 					<quaternion qw="-0.5086416113405852" qx="0.47228617443244963" qy="0.4771317600163493" qz="0.5390498717526195"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_3" tags="medium shield hittable">
+			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-89.41409999999999" y="-146.37800000000001" z="-318.3476"/>
 					<quaternion qw="-0.4297946403213763" qx="0.45638239325048" qy="-0.20117653869077176" qz="-0.7526750152372427"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_3" tags="medium shield hittable">
+			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="89.41409999999999" y="-146.37800000000001" z="-318.3476"/>
 					<quaternion qw="-0.4297946403213763" qx="0.45638239325048" qy="0.20117653869077176" qz="0.7526750152372427"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_2" tags="medium shield hittable">
+			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-80.4658" y="-135.8522" z="-151.6446"/>
 					<quaternion qw="-0.4629764871887026" qx="0.47009191081743684" qy="-0.4032950302330708" qz="-0.6340500660702802"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_2" tags="medium shield hittable">
+			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="80.4658" y="-135.8522" z="-151.6446"/>
 					<quaternion qw="-0.4629764871887026" qx="0.47009191081743684" qy="0.4032950302330708" qz="0.6340500660702802"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_1" tags="medium shield hittable">
+			<connection group="left-mid-side" name="con_shieldgen_m_left-mid-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-68.6616" y="-103.6176" z="73.23570000000001"/>
 					<quaternion qw="-0.6222258625631333" qx="0.10820538043437106" qy="-0.14664818705698293" qz="-0.7613283659732625"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_1" tags="medium shield hittable">
+			<connection group="right-mid-side" name="con_shieldgen_m_right-mid-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="68.6616" y="-103.6176" z="73.23570000000001"/>
 					<quaternion qw="-0.6222258625631333" qx="0.10820538043437106" qy="0.14664818705698293" qz="0.7613283659732625"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_shieldgen_m_bottomline_3" tags="medium shield hittable">
+			<connection group="bottomline" name="con_shieldgen_m_bottomline_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="0.00030000000000000003" y="-136.76319999999998" z="3.3039"/>
 					<quaternion qw="0.0007731731280700348" qx="-0.000460999843626323" qy="-0.05293298204484199" qz="-0.9985976612701928"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_shieldgen_m_bottomline_2" tags="medium shield hittable">
+			<connection group="bottomline" name="con_shieldgen_m_bottomline_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="0.026600000000000002" y="-122.2566" z="106.68530000000001"/>
 					<quaternion qw="0.005775141102292033" qx="-0.0019529671670328096" qy="-0.17232410291513722" qz="-0.985021439979347"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_shieldgen_m_bottomline_1" tags="medium shield hittable">
+			<connection group="bottomline" name="con_shieldgen_m_bottomline_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="0.0029" y="-113.94120000000001" z="183.2353"/>
 					<quaternion qw="1.673205103296542e-06" qx="9.200001663816775e-05" qy="-0.017135003098858743" qz="-0.9998531808230644"/>
 				</offset>
 			</connection>
-			<connection group="bottomnew" name="con_shieldgen_m_bottomnew_1" tags="medium shield hittable">
+			<connection group="bottomnew" name="con_shieldgen_m_bottomnew_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="12.5419" y="-137.33429999999998" z="-173.8654"/>
 					<quaternion qw="1.7320510330969933e-07" qx="-0.0" qy="0.0" qz="-0.999999999999985"/>
 				</offset>
 			</connection>
-			<connection group="left-back-side" name="con_shieldgen_m_left-back-side_2" tags="medium shield hittable">
+			<connection group="left-back-side" name="con_shieldgen_m_left-back-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-205.0102" y="-87.496" z="-711.8296"/>
 					<quaternion qw="-0.5038558042523983" qx="-0.16037776272664062" qy="0.1503129066863385" qz="-0.8353528187702908"/>
 				</offset>
 			</connection>
-			<connection group="right-back-side" name="con_shieldgen_m_right-back-side_2" tags="medium shield hittable">
+			<connection group="right-back-side" name="con_shieldgen_m_right-back-side_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="205.0102" y="-87.496" z="-711.8296"/>
 					<quaternion qw="-0.5038558042523983" qx="-0.16037776272664062" qy="-0.1503129066863385" qz="0.8353528187702908"/>
 				</offset>
 			</connection>
-			<connection group="left-back-side" name="con_shieldgen_m_left-back-side_1" tags="medium shield hittable">
+			<connection group="left-back-side" name="con_shieldgen_m_left-back-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-233.65879999999999" y="-29.6001" z="-724.5374"/>
 					<quaternion qw="-0.3991928357979495" qx="0.6576997126131645" qy="-0.34704416062938814" qz="-0.5363175537395691"/>
 				</offset>
 			</connection>
-			<connection group="right-back-side" name="con_shieldgen_m_right-back-side_1" tags="medium shield hittable">
+			<connection group="right-back-side" name="con_shieldgen_m_right-back-side_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="233.65879999999999" y="-29.6001" z="-724.5374"/>
 					<quaternion qw="-0.3991928357979495" qx="0.6576997126131645" qy="0.34704416062938814" qz="0.5363175537395691"/>
 				</offset>
 			</connection>
-			<connection group="backnew" name="con_shieldgen_m_backnew_2" tags="medium shield hittable">
+			<connection group="backnew" name="con_shieldgen_m_backnew_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-24.5309" y="79.9121" z="-1161.8682"/>
 					<quaternion qw="-0.9994611767748652" qx="0.02063318299961221" qy="-0.0" qz="-0.025527002940142013"/>
 				</offset>
 			</connection>
-			<connection group="left-back-wing" name="con_shieldgen_m_left-back-wing_1" tags="medium shield hittable">
+			<connection group="left-back-wing" name="con_shieldgen_m_left-back-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-200.2319" y="45.8787" z="-666.2185"/>
 					<quaternion qw="-0.9813990835972717" qx="0.04040937440743596" qy="-0.0783579676759311" qz="-0.17053723955820527"/>
 				</offset>
 			</connection>
-			<connection group="right-back-wing" name="con_shieldgen_m_right-back-wing_1" tags="medium shield hittable">
+			<connection group="right-back-wing" name="con_shieldgen_m_right-back-wing_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="200.2319" y="45.8787" z="-666.2185"/>
 					<quaternion qw="-0.9813990835972717" qx="0.04040937440743596" qy="0.0783579676759311" qz="0.17053723955820527"/>
 				</offset>
 			</connection>
-			<connection group="left-back-wing" name="con_shieldgen_m_left-back-wing_2" tags="medium shield hittable">
+			<connection group="left-back-wing" name="con_shieldgen_m_left-back-wing_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-229.7736" y="28.817999999999998" z="-758.0525"/>
 					<quaternion qw="-0.9488870847759128" qx="0.015640337562296124" qy="-0.029332694831292045" qz="-0.3138602765568486"/>
 				</offset>
 			</connection>
-			<connection group="right-back-wing" name="con_shieldgen_m_right-back-wing_2" tags="medium shield hittable">
+			<connection group="right-back-wing" name="con_shieldgen_m_right-back-wing_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="229.7736" y="28.817999999999998" z="-758.0525"/>
 					<quaternion qw="-0.9488870847759128" qx="0.015640337562296124" qy="0.029332694831292045" qz="0.3138602765568486"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_shieldgen_m_left-armor_3" tags="medium shield hittable">
+			<connection group="left-armor" name="con_shieldgen_m_left-armor_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="-68.42200000000001" y="82.2754" z="53.3806"/>
 					<quaternion qw="-0.6707042280556555" qx="0.15170648029636752" qy="-0.7070529837625106" qz="-0.164975939024107"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_shieldgen_m_right-armor_3" tags="medium shield hittable">
+			<connection group="right-armor" name="con_shieldgen_m_right-armor_3" tags="medium shield hittable standard">
 				<offset>
 					<position x="68.42200000000001" y="82.2754" z="53.3806"/>
 					<quaternion qw="-0.6707042280556555" qx="0.15170648029636752" qy="0.7070529837625106" qz="0.164975939024107"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_shieldgen_m_left-armor_2" tags="medium shield hittable">
+			<connection group="left-armor" name="con_shieldgen_m_left-armor_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-96.8124" y="48.931599999999996" z="431.4444"/>
 					<quaternion qw="-0.9644345803198074" qx="-0.052145859859252845" qy="0.13488348877260262" qz="-0.22125368706402898"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_shieldgen_m_right-armor_2" tags="medium shield hittable">
+			<connection group="right-armor" name="con_shieldgen_m_right-armor_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="96.8124" y="48.931599999999996" z="431.4444"/>
 					<quaternion qw="-0.9644345803198074" qx="-0.052145859859252845" qy="-0.13488348877260262" qz="0.22125368706402898"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_shieldgen_m_left-armor_1" tags="medium shield hittable">
+			<connection group="left-armor" name="con_shieldgen_m_left-armor_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-70.891" y="49.505700000000004" z="693.4566"/>
 					<quaternion qw="-0.974669461967442" qx="-0.06382212921014765" qy="0.10902248166894957" qz="-0.18455425820588356"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_shieldgen_m_right-armor_1" tags="medium shield hittable">
+			<connection group="right-armor" name="con_shieldgen_m_right-armor_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="70.891" y="49.505700000000004" z="693.4566"/>
 					<quaternion qw="-0.974669461967442" qx="-0.06382212921014765" qy="-0.10902248166894957" qz="0.18455425820588356"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_m_turret_left-armor_1" tags="turret medium standard hittable">
+			<connection group="left-armor" name="con_m_turret_left-armor_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-34.6539" y="54.9357" z="933.1697"/>
 					<quaternion qw="-0.9693836867451763" qx="-0.01677285799930794" qy="-0.001240278533012786" qz="-0.24497428603023938"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_m_turret_right-armor_1" tags="turret medium standard hittable">
+			<connection group="right-armor" name="con_m_turret_right-armor_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="34.6539" y="54.9357" z="933.1697"/>
 					<quaternion qw="-0.9693836867451763" qx="-0.01677285799930794" qy="0.001240278533012786" qz="0.24497428603023938"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_m_turret_left-armor_5" tags="turret medium standard hittable">
+			<connection group="left-armor" name="con_m_turret_left-armor_5" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-98.67439999999999" y="69.7129" z="-18.4543"/>
 					<quaternion qw="-0.9737593287921963" qx="-0.015941542029814237" qy="-0.003715020158957966" qz="-0.22699082680386334"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_m_turret_right-armor_5" tags="turret medium standard hittable">
+			<connection group="right-armor" name="con_m_turret_right-armor_5" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="98.67439999999999" y="69.7129" z="-18.4543"/>
 					<quaternion qw="-0.9737593287921963" qx="-0.015941542029814237" qy="0.003715020158957966" qz="0.22699082680386334"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_m_turret_left-armor_4" tags="turret medium standard hittable">
+			<connection group="left-armor" name="con_m_turret_left-armor_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-108.15920000000001" y="60.7105" z="150.0779"/>
 					<quaternion qw="-0.9751370888294361" qx="-0.013116210829446936" qy="-0.0022707611740444473" qz="-0.2212023206171683"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_m_turret_right-armor_4" tags="turret medium standard hittable">
+			<connection group="right-armor" name="con_m_turret_right-armor_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="108.15920000000001" y="60.7105" z="150.0779"/>
 					<quaternion qw="-0.9751370888294361" qx="-0.013116210829446936" qy="0.0022707611740444473" qz="0.2212023206171683"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_m_turret_left-armor_3" tags="turret medium standard hittable">
+			<connection group="left-armor" name="con_m_turret_left-armor_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-38.0805" y="80.3377" z="334.3701"/>
 					<quaternion qw="-0.9770856064546048" qx="-0.02251831467164173" qy="-0.004537250121511085" qz="-0.21160353618245814"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_m_turret_right-armor_3" tags="turret medium standard hittable">
+			<connection group="right-armor" name="con_m_turret_right-armor_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="38.0805" y="80.3377" z="334.3701"/>
 					<quaternion qw="-0.9770856064546048" qx="-0.02251831467164173" qy="0.004537250121511085" qz="0.21160353618245814"/>
 				</offset>
 			</connection>
-			<connection group="left-armor" name="con_m_turret_left-armor_2" tags="turret medium standard hittable">
+			<connection group="left-armor" name="con_m_turret_left-armor_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-54.0982" y="62.8015" z="540.6723000000001"/>
 					<quaternion qw="-0.9768230659634246" qx="-0.04248153315935954" qy="-0.008312139434653665" qz="-0.20962567943900426"/>
 				</offset>
 			</connection>
-			<connection group="right-armor" name="con_m_turret_right-armor_2" tags="turret medium standard hittable">
+			<connection group="right-armor" name="con_m_turret_right-armor_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="54.0982" y="62.8015" z="540.6723000000001"/>
 					<quaternion qw="-0.9768230659634246" qx="-0.04248153315935954" qy="0.008312139434653665" qz="0.20962567943900426"/>
 				</offset>
 			</connection>
-			<connection group="left-nose" name="con_m_turret_left-nose_2" tags="turret medium standard hittable">
+			<connection group="left-nose" name="con_m_turret_left-nose_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-30.234299999999998" y="-28.128999999999998" z="946.0124000000001"/>
 					<quaternion qw="-0.7298146743596939" qx="0.0028296080505842906" qy="-0.0" qz="0.6836391843710642"/>
 				</offset>
 			</connection>
-			<connection group="right-nose" name="con_m_turret_right-nose_2" tags="turret medium standard hittable">
+			<connection group="right-nose" name="con_m_turret_right-nose_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="30.234299999999998" y="-28.128999999999998" z="946.0124000000001"/>
 					<quaternion qw="-0.7298146743596939" qx="0.0028296080505842906" qy="0.0" qz="-0.6836391843710642"/>
 				</offset>
 			</connection>
-			<connection group="left-nose" name="con_m_turret_left-nose_1" tags="turret medium standard hittable">
+			<connection group="left-nose" name="con_m_turret_left-nose_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-32.4544" y="-82.017" z="987.3036000000001"/>
 					<quaternion qw="-0.7010802884898975" qx="-0.02442234567418687" qy="-0.03538669462120131" qz="-0.7117849113085207"/>
 				</offset>
 			</connection>
-			<connection group="right-nose" name="con_m_turret_right-nose_1" tags="turret medium standard hittable">
+			<connection group="right-nose" name="con_m_turret_right-nose_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="32.4544" y="-82.017" z="987.3036000000001"/>
 					<quaternion qw="-0.7010802884898975" qx="-0.02442234567418687" qy="0.03538669462120131" qz="0.7117849113085207"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_m_turret_bottomline_4" tags="turret medium standard hittable">
+			<connection group="bottomline" name="con_m_turret_bottomline_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-0.0" y="-139.931" z="-41.535"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-1.0000003245171046e-05" qy="-0.01553500504137322" qz="-0.999879324477838"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_m_turret_bottomline_3" tags="turret medium standard hittable">
+			<connection group="bottomline" name="con_m_turret_bottomline_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-0.0" y="-131.47729999999999" z="52.9126"/>
 					<quaternion qw="0.0007861731241186971" qx="-0.0002109999440130176" qy="-0.05293298595469696" qz="-0.9985977350308594"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_m_turret_bottomline_2" tags="turret medium standard hittable">
+			<connection group="bottomline" name="con_m_turret_bottomline_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-0.0" y="-115.33709999999999" z="142.5212"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-2.600000480336994e-05" qy="-0.017135003165605536" qz="-0.9998531847178402"/>
 				</offset>
 			</connection>
-			<connection group="bottomline" name="con_m_turret_bottomline_1" tags="turret medium standard hittable">
+			<connection group="bottomline" name="con_m_turret_bottomline_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0.0181" y="-112.5531" z="223.7224"/>
 					<quaternion qw="-3.2679489653813835e-07" qx="-2.600000480336994e-05" qy="-0.017135003165605536" qz="-0.9998531847178402"/>
 				</offset>
 			</connection>
-			<connection group="left-back-side" name="con_m_turret_left-back-side_3" tags="turret medium standard hittable">
+			<connection group="left-back-side" name="con_m_turret_left-back-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-223.482" y="-17.334600000000002" z="-878.6931"/>
 					<quaternion qw="-0.5242224811539634" qx="0.019667279076523884" qy="0.040554023129777884" qz="-0.8503877701346004"/>
 				</offset>
 			</connection>
-			<connection group="right-back-side" name="con_m_turret_right-back-side_3" tags="turret medium standard hittable">
+			<connection group="right-back-side" name="con_m_turret_right-back-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="223.482" y="-17.334600000000002" z="-878.6931"/>
 					<quaternion qw="-0.5242224811539634" qx="0.019667279076523884" qy="-0.040554023129777884" qz="0.8503877701346004"/>
 				</offset>
 			</connection>
-			<connection group="left-back-side" name="con_m_turret_left-back-side_2" tags="turret medium standard hittable">
+			<connection group="left-back-side" name="con_m_turret_left-back-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-235.96699999999998" y="-13.308800000000002" z="-783.9525"/>
 					<quaternion qw="-0.5443544206312003" qx="0.02060480275292157" qy="0.04342670006578987" qz="-0.8374770615152269"/>
 				</offset>
 			</connection>
-			<connection group="right-back-side" name="con_m_turret_right-back-side_2" tags="turret medium standard hittable">
+			<connection group="right-back-side" name="con_m_turret_right-back-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="235.96699999999998" y="-13.308800000000002" z="-783.9525"/>
 					<quaternion qw="-0.5443544206312003" qx="0.02060480275292157" qy="-0.04342670006578987" qz="0.8374770615152269"/>
 				</offset>
 			</connection>
-			<connection group="left-back-side" name="con_m_turret_left-back-side_1" tags="turret medium standard hittable">
+			<connection group="left-back-side" name="con_m_turret_left-back-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-219.14639999999997" y="-54.50319999999999" z="-741.1829"/>
 					<quaternion qw="-0.5216820182755433" qx="0.005498486015519955" qy="0.017791377403825158" qz="-0.852936753428745"/>
 				</offset>
 			</connection>
-			<connection group="right-back-side" name="con_m_turret_right-back-side_1" tags="turret medium standard hittable">
+			<connection group="right-back-side" name="con_m_turret_right-back-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="219.14639999999997" y="-54.50319999999999" z="-741.1829"/>
 					<quaternion qw="-0.5216820182755433" qx="0.005498486015519955" qy="-0.017791377403825158" qz="0.852936753428745"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_m_turret_left-mid-side_4" tags="turret medium standard hittable">
+			<connection group="left-mid-side" name="con_m_turret_left-mid-side_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-92.1405" y="-134.69230000000002" z="-370.507"/>
 					<quaternion qw="-0.4786055154164353" qx="0.017574655656466858" qy="0.03581222423362878" qz="-0.8771233531761455"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_m_turret_right-mid-side_4" tags="turret medium standard hittable">
+			<connection group="right-mid-side" name="con_m_turret_right-mid-side_4" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="92.1405" y="-134.69230000000002" z="-370.507"/>
 					<quaternion qw="-0.4786055154164353" qx="0.017574655656466858" qy="-0.03581222423362878" qz="0.8771233531761455"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_m_turret_left-mid-side_3" tags="turret medium standard hittable">
+			<connection group="left-mid-side" name="con_m_turret_left-mid-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-87.1582" y="-127.64040000000001" z="-190.2804"/>
 					<quaternion qw="-0.6078068683923032" qx="-0.0232730269515686" qy="-0.02630325319857234" qz="-0.7933078316913459"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_m_turret_right-mid-side_3" tags="turret medium standard hittable">
+			<connection group="right-mid-side" name="con_m_turret_right-mid-side_3" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="87.1582" y="-127.64040000000001" z="-190.2804"/>
 					<quaternion qw="-0.6078068683923032" qx="-0.0232730269515686" qy="0.02630325319857234" qz="0.7933078316913459"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_m_turret_left-mid-side_2" tags="turret medium standard hittable">
+			<connection group="left-mid-side" name="con_m_turret_left-mid-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-74.6678" y="-122.11099999999999" z="-21.8114"/>
 					<quaternion qw="-0.6153578177903914" qx="-0.02904535910953885" qy="-0.034282478245551015" qz="-0.786966222200031"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_m_turret_right-mid-side_2" tags="turret medium standard hittable">
+			<connection group="right-mid-side" name="con_m_turret_right-mid-side_2" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="74.6678" y="-122.11099999999999" z="-21.8114"/>
 					<quaternion qw="-0.6153578177903914" qx="-0.02904535910953885" qy="0.034282478245551015" qz="0.786966222200031"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-side" name="con_m_turret_left-mid-side_1" tags="turret medium standard hittable">
+			<connection group="left-mid-side" name="con_m_turret_left-mid-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-64.5638" y="-117.2449" z="115.8816"/>
 					<quaternion qw="-0.6447524042996395" qx="-0.023002065220789743" qy="-0.02930065014101131" qz="-0.7634832768612072"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-side" name="con_m_turret_right-mid-side_1" tags="turret medium standard hittable">
+			<connection group="right-mid-side" name="con_m_turret_right-mid-side_1" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="64.5638" y="-117.2449" z="115.8816"/>
 					<quaternion qw="-0.6447524042996395" qx="-0.023002065220789743" qy="0.02930065014101131" qz="0.7634832768612072"/>
 				</offset>
 			</connection>
-			<connection group="bottomnew" name="con_l_turret_bottomnew_1" tags="turret large standard highpower splonly hittable">
+			<connection group="bottomnew" name="con_l_turret_bottomnew_1" tags="turret large standard highpower hittable splonly combat">
 				<offset>
 					<position x="-0.0" y="-137.346" z="-120.77310000000001"/>
 					<quaternion qw="6.732051033795384e-07" qx="-0.0" qy="0.0" qz="-0.9999999999997734"/>
 				</offset>
 			</connection>
-			<connection group="backnew" name="con_l_turret_backnew_1" tags="turret large standard hittable">
+			<connection group="backnew" name="con_l_turret_backnew_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-0.0" y="78.7029" z="-1111.0145"/>
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection group="left-back-wing" name="con_l_turret_left-back-wing_1" tags="turret large standard hittable">
+			<connection group="left-back-wing" name="con_l_turret_left-back-wing_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-186.2983" y="45.3813" z="-781.3007"/>
 					<quaternion qw="-0.9815941048924106" qx="0.008332412061842357" qy="0.051432161988325495" qz="-0.18373436494816475"/>
 				</offset>
 			</connection>
-			<connection group="right-back-wing" name="con_l_turret_right-back-wing_1" tags="turret large standard hittable">
+			<connection group="right-back-wing" name="con_l_turret_right-back-wing_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="186.2983" y="45.3813" z="-781.3007"/>
 					<quaternion qw="-0.9815941048924106" qx="0.008332412061842357" qy="-0.051432161988325495" qz="0.18373436494816475"/>
 				</offset>
 			</connection>
-			<connection group="left-mid-wing" name="con_l_turret_left-mid-wing_1" tags="turret large standard hittable">
+			<connection group="left-mid-wing" name="con_l_turret_left-mid-wing_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-215.4372" y="-62.010299999999994" z="-536.285"/>
 					<quaternion qw="-0.4700154896470465" qx="-0.04669527090554241" qy="-0.028236238328040026" qz="-0.8809697531765703"/>
 				</offset>
 			</connection>
-			<connection group="right-mid-wing" name="con_l_turret_right-mid-wing_1" tags="turret large standard hittable">
+			<connection group="right-mid-wing" name="con_l_turret_right-mid-wing_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="215.4372" y="-62.010299999999994" z="-536.285"/>
 					<quaternion qw="-0.4700154896470465" qx="-0.04669527090554241" qy="0.028236238328040026" qz="0.8809697531765703"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_l_turret_left-front_2" tags="turret large standard hittable">
+			<connection group="left-front" name="con_l_turret_left-front_2" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-46.7036" y="-66.7008" z="503.76079999999996"/>
 					<quaternion qw="-0.6854815104430418" qx="-0.011126667824988487" qy="-0.010274802797162513" qz="-0.7279324999828747"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_l_turret_right-front_2" tags="turret large standard hittable">
+			<connection group="right-front" name="con_l_turret_right-front_2" tags="turret large standard hittable combat">
 				<offset>
 					<position x="46.7036" y="-66.7008" z="503.76079999999996"/>
 					<quaternion qw="-0.6854815104430418" qx="-0.011126667824988487" qy="0.010274802797162513" qz="0.7279324999828747"/>
 				</offset>
 			</connection>
-			<connection group="left-front" name="con_l_turret_left-front_1" tags="turret large standard hittable">
+			<connection group="left-front" name="con_l_turret_left-front_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-37.2442" y="-30.5843" z="867.1315"/>
 					<quaternion qw="-0.6968383324592655" qx="-0.012393701161282748" qy="-0.011953323122334391" qz="-0.7170215147771005"/>
 				</offset>
 			</connection>
-			<connection group="right-front" name="con_l_turret_right-front_1" tags="turret large standard hittable">
+			<connection group="right-front" name="con_l_turret_right-front_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="37.2442" y="-30.5843" z="867.1315"/>
 					<quaternion qw="-0.6968383324592655" qx="-0.012393701161282748" qy="0.011953323122334391" qz="0.7170215147771005"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="-0.0" y="-73.142" z="-650.3082"/>
 					<quaternion qw="-0.0005398267686779208" qx="-1.4000000089222447e-05" qy="0.025211000160670512" qz="-0.9996820063710053"/>
 				</offset>
 			</connection>
-			<connection group="backfin" name="con_shieldgen_m_backfin_2" tags="medium shield hittable">
+			<connection group="backfin" name="con_shieldgen_m_backfin_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="22.9185" y="-57.564800000000005" z="-803.6894"/>
 					<quaternion qw="-0.20598611544831436" qx="0.9785487571899201" qy="-0.003400477334098977" qz="-0.0006977094501331139"/>
 				</offset>
 			</connection>
-			<connection group="backfin" name="con_shieldgen_m_backfin_1" tags="medium shield hittable">
+			<connection group="backfin" name="con_shieldgen_m_backfin_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="-22.9185" y="-57.564800000000005" z="-803.6894"/>
 					<quaternion qw="-0.20598611544831436" qx="0.9785487571899201" qy="-0.003400477334098977" qz="-0.0006977094501331139"/>
 				</offset>
 			</connection>
-			<connection group="backfin" name="con_l_turret_backfin_1" tags="turret large standard hittable">
+			<connection group="backfin" name="con_l_turret_backfin_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-0.0" y="-27.282" z="-874.15"/>
 					<quaternion qw="-0.20139346477349923" qx="0.979510424827896" qy="0.0" qz="-0.0"/>

--- a/assets/units/size_xl/ship_spl_xl_gharial.xml
+++ b/assets/units/size_xl/ship_spl_xl_gharial.xml
@@ -1144,7 +1144,7 @@
 					<quaternion qx="8.813973E-08" qy="8.234808E-03" qz="-8.669991E-08" qw="-0.9999661"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_down" tags="engine extralarge">
+			<connection name="con_engine_02" group="group_back_mid_down" tags="engine extralarge standard">
 				<offset>
 					<position x="122.876" y="-33.05833" z="-837.7014"/>
 				</offset>
@@ -1234,7 +1234,7 @@
 					<quaternion qx="-3.300423E-03" qy="3.28738E-07" qz="-0.9999946" qw="8.770963E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge standard">
 				<offset>
 					<position x="-122.8756" y="-33.05833" z="-837.7014"/>
 				</offset>

--- a/assets/units/size_xl/ship_spl_xl_gharial.xml
+++ b/assets/units/size_xl/ship_spl_xl_gharial.xml
@@ -1211,7 +1211,7 @@
 					<position x="-5.803196" y="155.9882" z="427.0415"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="77.54224" z="-840.3771"/>
 				</offset>

--- a/assets/units/size_xl/ship_tel_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_battleship_01.xml
@@ -490,234 +490,234 @@
 					<position x="0.1350555" y="89.62669" z="-1155.65"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_engines01" group="group_back_bottom " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_engines01" group="group_back_bottom " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-0" y="192" z="-1065"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE left_turret_large-->
-			<connection name="con_turret_ltL01" group="group_left_turret_large " tags="turret large highpower telonly standard ">
+			<connection name="con_turret_ltL01" group="group_left_turret_large " tags="turret large highpower standard telonly combat">
 				<offset>
 					<position x="0" y="150" z="685"/>
 					<rotation yaw="0" pitch="-80" roll="0" />
 				</offset>
 			</connection>
-			<connection name="con_turret_ltL02" group="group_left_turret_large " tags="turret large highpower telonly standard ">
+			<connection name="con_turret_ltL02" group="group_left_turret_large " tags="turret large highpower standard telonly combat">
 				<offset>
 					<position x="0" y="-150" z="685"/>
 					<rotation yaw="0" pitch="-100" roll="0" />
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_ltL01" group="group_left_turret_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_ltL01" group="group_left_turret_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="-94" y="54.5" z="-925"/>
 					<quaternion qx="0.3535534" qy="-0.6123725" qz="-0.3535534" qw="-0.6123723"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE right_turret_large-->
-			<connection name="con_turret_rtL01" group="group_right_turret_large " tags="turret large highpower telonly standard ">
+			<connection name="con_turret_rtL01" group="group_right_turret_large " tags="turret large highpower standard telonly combat">
 				<offset>
 					<position x="150" y="0" z="685"/>
 					<rotation yaw="0" pitch="-90" roll="20" />
 				</offset>
 			</connection>
-			<connection name="con_turret_rtL02" group="group_right_turret_large " tags="turret large highpower telonly standard ">
+			<connection name="con_turret_rtL02" group="group_right_turret_large " tags="turret large highpower standard telonly combat">
 				<offset>
 					<position x="-150" y="0" z="685"/>
 					<rotation yaw="0" pitch="-90" roll="-20" />
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_rtL01" group="group_right_turret_large " tags="large shield hittable ">
+			<connection name="con_shieldgen_l_rtL01" group="group_right_turret_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="94" y="54.5" z="-925"/>
 					<quaternion qx="0.3535534" qy="0.6123724" qz="0.3535534" qw="-0.6123724"/>
 				</offset>
 			</connection>
 <!--Turrets LARGE down_turret_large-->
-			<connection name="con_turret_dtL02" group="group_down_turret_large " tags="turret large standard ">
+			<connection name="con_turret_dtL02" group="group_down_turret_large " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-100" z="-744"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
-			<connection group="group_down_turret_large" name="con_turret_dtL01" tags="turret large standard ">
+			<connection group="group_down_turret_large" name="con_turret_dtL01" tags="turret large standard combat">
 				<offset>
 					<position x="91.2603" y="44.9375" z="-744"/>
 					<quaternion qw="-0.866320890182167" qx="4.994878529381174e-07" qy="9.989757058762348e-07" qz="0.4994878529381174"/>
 				</offset>
 			</connection>
-			<connection group="group_down_turret_large" name="con_turret_dtL03" tags="turret large  standard ">
+			<connection group="group_down_turret_large" name="con_turret_dtL03" tags="turret large standard combat">
 				<offset>
 					<position x="-91.26100000000001" y="44.9375" z="-744"/>
 					<quaternion qw="-0.8663228881266481" qx="-9.989687752996233e-07" qy="9.989687752996233e-07" qz="-0.4994843876498116"/>
 				</offset>
 			</connection>
-					<connection name="con_shieldgen_l_dtL01" group="group_down_turret_large " tags="large shield hittable ">
+					<connection name="con_shieldgen_l_dtL01" group="group_down_turret_large " tags="large shield hittable standard ">
 				<offset>
 					<position x="0" y="-109" z="-925"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM center_bottom_left-->	
-			<connection name="con_turret_cblM01" group="group_center_bottom_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cblM01" group="group_center_bottom_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-116.8888" y="-67.50318" z="143"/>
 					<quaternion qx="4.451076E-07" qy="4.451076E-07" qz="-0.8660254" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_cblM02" group="group_center_bottom_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cblM02" group="group_center_bottom_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-116.8888" y="-67.50318" z="65"/>
 					<quaternion qx="4.451076E-07" qy="4.451076E-07" qz="-0.8660254" qw="-0.5"/>
 				</offset>
 			</connection>	
-			<connection name="con_shieldgen_m_cbmM01" group="group_center_bottom_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_cbmM01" group="group_center_bottom_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-116.8888" y="-67.50233" z="104.9013"/>
 					<quaternion qx="-2.499755E-07" qy="-2.819745E-07" qz="-0.8660254" qw="-0.5"/>
 				</offset>
 			</connection>			
 <!--Turrets MEDIUM center_bottom_right-->			
-			<connection name="con_turret_cbrM01" group="group_center_bottom_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cbrM01" group="group_center_bottom_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="117.3849" y="-67.78113" z="143"/>
 					<quaternion qx="3.576848E-07" qy="-2.936869E-07" qz="-0.8660254" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_cbrM02" group="group_center_bottom_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cbrM02" group="group_center_bottom_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="117.3849" y="-67.78113" z="65"/>
 					<quaternion qx="3.576848E-07" qy="-2.936869E-07" qz="-0.8660254" qw="0.5"/>
 				</offset>
 			</connection>				
-			<connection name="con_shieldgen_m_cbrM01" group="group_center_bottom_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_cbrM01" group="group_center_bottom_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="117.385" y="-67.78028" z="104.9012"/>
 					<quaternion qx="-1.033445E-07" qy="1.607725E-08" qz="0.8660254" qw="-0.5000001"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM center_top_center-->	
-			<connection name="con_turret_cbcM01" group="group_center_top_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cbcM01" group="group_center_top_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="1.032246E-02" y="135.5644" z="143"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_cbcM02" group="group_center_top_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_cbcM02" group="group_center_top_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="1.032246E-02" y="135.5644" z="65"/>
 				</offset>
 			</connection>			
-			<connection name="con_shieldgen_m_cbcM01" group="group_center_top_center " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_cbcM01" group="group_center_top_center " tags="medium shield hittable standard ">
 				<offset>
 					<position x="1.032246E-02" y="135.5652" z="104.9736"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM back_bottom_left-->			
-			<connection name="con_turret_bbl01" group="group_back_bottom_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bbl01" group="group_back_bottom_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-117.5109" y="-67.85088" z="-910"/>
 					<quaternion qx="1.629776E-07" qy="-4.355587E-08" qz="-0.8660254" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bbl02" group="group_back_bottom_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bbl02" group="group_back_bottom_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-166" y="-96" z="-1100"/>
 					<quaternion qx="1.629776E-07" qy="-4.355587E-08" qz="-0.8660254" qw="-0.5"/>
 				</offset>
 			</connection>		
-			<connection name="con_shieldgen_m_bbl01" group="group_back_bottom_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bbl01" group="group_back_bottom_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-117.5109" y="-67.85088" z="-928"/>
 					<quaternion qx="-1.307662E-07" qy="-7.549789E-08" qz="-0.8660254" qw="-0.4999999"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM back_bottom_right-->			
-			<connection name="con_turret_bbr01" group="group_back_bottom_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bbr01" group="group_back_bottom_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="117.5138" y="-67.84444" z="-910"/>
 					<quaternion qx="2.225823E-07" qy="-5.968241E-08" qz="-0.8660254" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_bbr02" group="group_back_bottom_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_bbr02" group="group_back_bottom_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="166" y="-96" z="-1100"/>
 					<quaternion qx="2.225823E-07" qy="-5.968241E-08" qz="-0.8660254" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_bbr01" group="group_back_bottom_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_bbr01" group="group_back_bottom_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="117.5138" y="-67.84443" z="-928"/>
 					<quaternion qx="1.307662E-07" qy="-7.549792E-08" qz="0.8660254" qw="-0.5000001"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM back_top_center-->			
-			<connection name="con_turret_btc01" group="group_back_top_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_btc01" group="group_back_top_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-0" y="135.7075" z="-910"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_btc02" group="group_back_top_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_btc02" group="group_back_top_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-0" y="192" z="-1100"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_btc01" group="group_back_top_center " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_btc01" group="group_back_top_center " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-0" y="135.7075" z="-928"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_top_left-->			
-			<connection name="con_turret_ftl01" group="group_front_top_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ftl01" group="group_front_top_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-371.3223" y="146.0084" z="559.9584"/>
 					<quaternion qx="-0.3426389" qy="-0.2253904" qz="-0.510629" qw="-0.7556823"/>
 				</offset>
 			</connection>		
-			<connection name="con_turret_ftl02" group="group_front_top_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ftl02" group="group_front_top_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-311.9288" y="248.9608" z="559.8674"/>
 					<quaternion qx="-0.3668191" qy="-0.1834097" qz="-0.3988445" qw="-0.8201998"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_ftl01" group="group_front_top_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_ftl01" group="group_front_top_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-118" y="68" z="270"/>
 					<quaternion qx="0.3535534" qy="-0.6123725" qz="-0.3535534" qw="-0.6123723"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_top_right-->			
-			<connection name="con_turret_ftr01" group="group_front_top_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ftr01" group="group_front_top_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="371.133" y="146.4019" z="559.9857"/>
 					<quaternion qx="-0.3396097" qy="0.2298603" qz="0.5126483" qw="-0.7543349"/>
 				</offset>
 			</connection>			
-			<connection name="con_turret_ftr02" group="group_front_top_right " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_ftr02" group="group_front_top_right " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="312.6584" y="248.2852" z="559.7327"/>
 					<quaternion qx="-0.3657808" qy="0.1855423" qz="0.399797" qw="-0.81972"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_ftr01" group="group_front_top_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_ftr01" group="group_front_top_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="118" y="68" z="270"/>
 					<quaternion qx="0.3535534" qy="0.6123724" qz="0.3535534" qw="-0.6123724"/>
 				</offset>
 			</connection>
 <!--Turrets MEDIUM front_down_center-->			
-			<connection name="con_turret_fdc01" group="group_front_down_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdc01" group="group_front_down_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="59.75798" y="-393.7805" z="560.5874"/>
 					<quaternion qx="0.037473" qy="-0.4084209" qz="-0.909296" qw="7.049032E-02"/>
 				</offset>
 			</connection>			
-			<connection name="con_turret_fdc02" group="group_front_down_center " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_fdc02" group="group_front_down_center " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-58.95737" y="-394.3227" z="560.2162"/>
 					<quaternion qx="-3.853039E-02" qy="-0.4083388" qz="-0.9092517" qw="-0.0709654"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_fdc01" group="group_front_down_center " tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_fdc01" group="group_front_down_center " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-136" z="270"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>

--- a/assets/units/size_xl/ship_tel_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_battleship_01.xml
@@ -456,19 +456,19 @@
  			</connection>
 <!--=================================================================EDITS BY BLACKSCORP81=================================================================-->			
 <!--Main Shields XtraLARGE-->
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="95.88" y="55.35962" z="104.6917"/>
 					<quaternion qx="0.3535534" qy="0.6123724" qz="0.3535534" qw="-0.6123724"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_002" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_002" tags="extralarge shield standard">
 				<offset>
 					<position x="0" y="-110" z="104.7198"/>
 					<quaternion qx="-0.7071068" qy="-2.219725E-07" qz="0.7071068" qw="-8.432165E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_003" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_003" tags="extralarge shield standard">
 				<offset>
 					<position x="-95.86763" y="55.2746" z="104.7198"/>
 					<quaternion qx="0.3535534" qy="-0.6123725" qz="-0.3535534" qw="-0.6123723"/>

--- a/assets/units/size_xl/ship_tel_xl_battleship_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_battleship_01.xml
@@ -475,17 +475,17 @@
 				</offset>
 			</connection>
 <!--Engines XtraLARGE-->			
-			<connection name="con_engine_01" group="group_back_bottom " tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_bottom " tags="engine extralarge standard">
 				<offset>
 					<position x="77.533" y="-44.78594" z="-1155.65"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_bottom " tags="engine extralarge">
+			<connection name="con_engine_02" group="group_back_bottom " tags="engine extralarge standard">
 				<offset>
 					<position x="-77.44943" y="-44.74587" z="-1155.65"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_bottom " tags="engine extralarge">
+			<connection name="con_engine_03" group="group_back_bottom " tags="engine extralarge standard">
 				<offset>
 					<position x="0.1350555" y="89.62669" z="-1155.65"/>
 				</offset>

--- a/assets/units/size_xl/ship_tel_xl_carrier_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_carrier_01.xml
@@ -34,7 +34,7 @@
 
 
 
-		<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+		<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 			<offset>
 				<position x="0.3543" y="-110.932" z="105.8463"/>
 				<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="0.0" qz="0.7071067811865369"/>

--- a/assets/units/size_xl/ship_tel_xl_carrier_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_carrier_01.xml
@@ -10,20 +10,20 @@
 				<quaternion qw="-0.9382452058177569" qx="-0.3459710013281385" qy="0.0" qz="-0.0"/>
 			</offset>
 		</connection>
-		<connection name="con_shieldgen_m_020" group="group_front_top" tags="medium shield hittable ">
+		<connection name="con_shieldgen_m_020" group="group_front_top" tags="medium shield hittable standard ">
 			<offset>
 				<position x="0.0854" y="473.50269999999995" z="467.02380000000005"/>
 				<quaternion qw="-0.9503509690689104" qx="-0.3111800693967769" qy="0.0" qz="-0.0"/>
 			</offset>
 		</connection>
 
-		<!-- <connection name="con_turret_laser_l_03" group="group_front_bottom" tags="turret large standard missile ">
+		<!-- <connection name="con_turret_laser_l_03" group="group_front_bottom" tags="turret large standard missile combat">
 			<offset>
 				<position x="-0.0" y="-432.5445" z="514.3288"/>
 				<quaternion qw="0.9382452058177569" qx="0.3459710013281385" qy="0.0" qz="-0.0"/>
 			</offset>
 		</connection>
-		<connection name="con_shieldgen_m_021" group="group_front_bottom" tags="medium shield hittable ">
+		<connection name="con_shieldgen_m_021" group="group_front_bottom" tags="medium shield hittable standard ">
 			<offset>
 				<position x="0.0854" y="-473.50269999999995" z="467.02380000000005"/>
 				<quaternion qw="0.9503509690689104" qx="0.3111800693967769" qy="0.0" qz="-0.0"/>
@@ -41,19 +41,19 @@
 			</offset>
 		</connection>
 		
-		<!-- <connection group="group_back_bottom" name="con_shieldgen_m_017" tags="medium shield hittable">
+		<!-- <connection group="group_back_bottom" name="con_shieldgen_m_017" tags="medium shield hittable standard">
 			<offset>
 				<position x="0.21359999999999998" y="177.3415" z="-874.4173"/>
 				<quaternion qw="-0.5000000443375536" qx="0.49999998522081457" qy="0.49999998522081457" qz="-0.49999998522081457"/>
 			</offset>
 		</connection>
-		<connection group="group_back_bottom" name="con_shieldgen_m_018" tags="medium shield hittable">
+		<connection group="group_back_bottom" name="con_shieldgen_m_018" tags="medium shield hittable standard">
 			<offset>
 				<position x="154.921" y="-89.6637" z="-874.452"/>
 				<quaternion qw="-0.6896048957163101" qx="0.6896048042930053" qy="-0.15634945107051515" qz="0.15634945107051515"/>
 			</offset>
 		</connection>
-		<connection group="group_back_bottom" name="con_shieldgen_m_019" tags="medium shield hittable">
+		<connection group="group_back_bottom" name="con_shieldgen_m_019" tags="medium shield hittable standard">
 			<offset>
 				<position x="-152.9657" y="-90.80030000000001" z="-874.4118000000001"/>
 				<quaternion qw="-0.6802237388977704" qx="0.6802236589714332" qy="0.193120996806993" qz="-0.193120996806993"/>

--- a/assets/units/size_xl/ship_tel_xl_resupplier_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_resupplier_01.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <diff>
 	<add sel="//components/component/connections">
-		<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+		<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 						<position x="0.055400000000000005" y="-111.0295" z="105.47500000000001"/>
 						<quaternion qw="1.7320510330969933e-07" qx="-0.7071067811865369" qy="-0.0" qz="0.7071067811865369"/>

--- a/assets/units/size_xl/ship_tel_xl_resupplier_01.xml
+++ b/assets/units/size_xl/ship_tel_xl_resupplier_01.xml
@@ -8,19 +8,19 @@
 				</offset>
 		</connection>
 
-		<connection group="group_back_bottom" name="con_shieldgen_m_016" tags="medium shield hittable">
+		<connection group="group_back_bottom" name="con_shieldgen_m_016" tags="medium shield hittable standard">
 				<offset>
 						<position x="0.2291" y="179.4082" z="-1136.1376"/>
 						<quaternion qw="-0.5000000443375536" qx="0.49999998522081457" qy="-0.49999998522081457" qz="0.49999998522081457"/>
 				</offset>
 		</connection>
-		<connection group="group_back_bottom" name="con_shieldgen_m_017" tags="medium shield hittable">
+		<connection group="group_back_bottom" name="con_shieldgen_m_017" tags="medium shield hittable standard">
 				<offset>
 						<position x="155.3039" y="-89.79169999999999" z="-1135.9190999999998"/>
 						<quaternion qw="-0.6830126379815838" qx="0.6830126801437515" qy="-0.18301286173420625" qz="0.18301286173420625"/>
 				</offset>
 		</connection>
-		<connection group="group_back_bottom" name="con_shieldgen_m_018" tags="medium shield hittable">
+		<connection group="group_back_bottom" name="con_shieldgen_m_018" tags="medium shield hittable standard">
 				<offset>
 						<position x="-155.33950000000002" y="-89.6117" z="-1135.9203"/>
 						<quaternion qw="-0.6830126379815838" qx="0.6830126801437515" qy="0.18301286173420625" qz="-0.18301286173420625"/>

--- a/assets/units/size_xl/ship_ter_xl_sapporo.xml
+++ b/assets/units/size_xl/ship_ter_xl_sapporo.xml
@@ -272,744 +272,744 @@
 				</offset>
 			</connection>
 			<!-- L Battery 01 -->
-			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_01" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="69.49" z="129.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_02" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="82.85" z="38.79"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_03" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="95.47" z="-52.95"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_04" group="group_main_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_04" group="group_main_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0" y="95.47" z="-130.14"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="8" y="95.47" z="-90.3519"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-8" y="95.47" z="-90.3519"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_018" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_018" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="8" y="82.85" z="-0.2034"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_019" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_019" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-8" y="82.85" z="-0.2034"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_020" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_020" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="8" y="69.4995" z="170.811"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_021" group="group_main_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_021" group="group_main_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-8" y="69.4995" z="170.811"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Battery 02 -->
-			<connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_05" group="group_aft_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="95.47" z="-495.3"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_06" group="group_aft_battery " tags="turret large standard terronly">
+			<!-- <connection name="con_turret_laser_l_06" group="group_aft_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="82.85" z="-576.8"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_07" group="group_aft_battery " tags="turret large standard terronly">
+			<connection name="con_turret_laser_l_07" group="group_aft_battery " tags="turret large standard terronly combat">
 				<offset>
 					<position x="0" y="69.49" z="-656.17"/>
 					<rotation yaw="-180" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_003" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.9564" y="57.0173" z="-580.589"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-75.9564" y="57.0173" z="-580.589"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgen_022" group="group_aft_battery " tags="medium shield hittable ">
+			<!-- <connection name="con_shieldgen_022" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.9564" y="57.0173" z="-627.8"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_023" group="group_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_023" group="group_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-75.9564" y="57.0173" z="-627.8"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 03 -->
-			<connection name="con_turret_laser_l_08" group="group_front_deck_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_08" group="group_front_deck_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="56.98" z="675.7"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_09" group="group_front_deck_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_09" group="group_front_deck_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="69.49" z="583.3"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_21" group="group_front_deck_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_21" group="group_front_deck_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="54.3739" z="767.227"/>
 					<rotation yaw="0" pitch="-3.4744" roll="0"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_22" group="group_front_deck_battery " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_22" group="group_front_deck_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0" y="47.723" z="867.638"/>
 					<rotation yaw="0" pitch="-4.15189" roll="0"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_005" group="group_front_deck_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group_front_deck_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.143" y="69.49" z="543.563"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_028" group="group_front_deck_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_028" group="group_front_deck_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.143" y="69.49" z="543.563"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_029" group="group_front_deck_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_029" group="group_front_deck_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.143" y="43.8941" z="919.358"/>
 					<rotation yaw="90" pitch="0" roll="-4.15189"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_030" group="group_front_deck_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_030" group="group_front_deck_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.143" y="43.8941" z="919.358"/>
 					<rotation yaw="-90" pitch="0" roll="4.15189"/>
 				</offset>
 			</connection>
 			<!-- L Battery 04 -->
-			<!-- <connection name="con_turret_laser_l_10" group="group_front_prow_battery " tags="turret large standard highpower terronly">
+			<!-- <connection name="con_turret_laser_l_10" group="group_front_prow_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0 " y="-44.61" z="1117.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_23" group="group_front_prow_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_23" group="group_front_prow_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="0 " y="23.1957" z="982.117"/>
 					<rotation yaw="0" pitch="-19.785" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group_front_prow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group_front_prow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="15.1899" y="-39.88" z="1041.4"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_031" group="group_front_prow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_031" group="group_front_prow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-15.1899" y="-39.88" z="1041.4"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 05 -->
-			<!-- <connection name="con_turret_laser_l_11" group="group_mid_port_battery " tags="turret large missile standard ">
+			<!-- <connection name="con_turret_laser_l_11" group="group_mid_port_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="93.51 " y="69.49" z="-312.1"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_12" group="group_mid_port_battery " tags="turret large missile standard ">
+			<connection name="con_turret_laser_l_12" group="group_mid_port_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="93.51 " y="69.49" z="-400.8"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group_mid_port_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group_mid_port_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="76.1945" y="69.49" z="-355.5"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_032" group="group_mid_port_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_032" group="group_mid_port_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="107.123" y="69.49" z="-355.5"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 06 -->
-			<!-- <connection name="con_turret_laser_l_13" group="group_mid_starboard_battery " tags="turret large missile standard ">
+			<!-- <connection name="con_turret_laser_l_13" group="group_mid_starboard_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="-93.51 " y="69.49" z="-312.1"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_14" group="group_mid_starboard_battery " tags="turret large missile standard ">
+			<connection name="con_turret_laser_l_14" group="group_mid_starboard_battery " tags="turret large missile standard combat">
 				<offset>
 					<position x="-93.51 " y="69.49" z="-400.8"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group_mid_starboard_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group_mid_starboard_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-76.1945" y="69.49" z="-355.5"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_033" group="group_mid_starboard_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_033" group="group_mid_starboard_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-107.123" y="69.49" z="-355.5"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 07 -->
-			<connection name="con_turret_laser_l_15" group="group_keel_port_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_15" group="group_keel_port_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="184.23 " y="-17.71" z="-14.88"/>
 					<rotation yaw="0" pitch="0" roll="-187.33"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_16" group="group_keel_port_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_16" group="group_keel_port_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="184.23 " y="-17.71" z="-159.1"/>
 					<rotation yaw="180" pitch="0" roll="187.33"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_009" group="group_keel_port_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_009" group="group_keel_port_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="168.09" y="-19.63" z="-87.5267"/>
 					<rotation yaw="0" pitch="0" roll="-187.17"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_034" group="group_keel_port_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_034" group="group_keel_port_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="168.09" y="-19.63" z="-228.625"/>
 					<rotation yaw="0" pitch="0" roll="-187.17"/>
 				</offset>
 			</connection>
 			<!-- L Battery 08 -->
-			<connection name="con_turret_laser_l_17" group="group_keel_starboard_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_17" group="group_keel_starboard_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="-184.23 " y="-17.71" z="-14.88"/>
 					<rotation yaw="0" pitch="0" roll="-172.67"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_18" group="group_keel_starboard_battery " tags="turret large standard highpower terronly">
+			<connection name="con_turret_laser_l_18" group="group_keel_starboard_battery " tags="turret large standard highpower terronly combat">
 				<offset>
 					<position x="-184.23 " y="-17.71" z="-159.1"/>
 					<rotation yaw="180" pitch="0" roll="172.67"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_010" group="group_keel_starboard_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_010" group="group_keel_starboard_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-168.09" y="-19.63" z="-87.5267"/>
 					<rotation yaw="0" pitch="0" roll="172.67"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_035" group="group_keel_starboard_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_035" group="group_keel_starboard_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-168.09" y="-19.63" z="-228.625"/>
 					<rotation yaw="0" pitch="0" roll="172.67"/>
 				</offset>
 			</connection>
 			<!-- L Battery 09 -->
-			<connection name="con_turret_laser_l_19" group="group_keel_aft_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_19" group="group_keel_aft_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-93.24" z="-732.6"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_keel_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_keel_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="20.7407" y="-93.24" z="-789.55"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_036" group="group_keel_aft_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_036" group="group_keel_aft_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-20.7407" y="-93.24" z="-789.55"/>
 					<rotation yaw="-90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- L Battery 10 -->
-			<!-- <connection name="con_turret_laser_l_20" group="group_keel_prow_battery " tags="turret large standard ">
+			<!-- <connection name="con_turret_laser_l_20" group="group_keel_prow_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-91" z="762.0"/>
 					<rotation yaw="0" pitch="3.54" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_24" group="group_keel_prow_battery " tags="turret large standard ">
+			<connection name="con_turret_laser_l_24" group="group_keel_prow_battery " tags="turret large standard combat">
 				<offset>
 					<position x="0 " y="-106.313" z="1059.36"/>
 					<rotation yaw="0" pitch="4.54018" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_012" group="group_keel_prow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_012" group="group_keel_prow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="19.3027" y="-88.27" z="805.6"/>
 					<rotation yaw="90" pitch="-3.54" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_037" group="group_keel_prow_battery " tags="medium shield hittable ">
+			<connection name="con_shieldgen_037" group="group_keel_prow_battery " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-19.3027" y="-88.27" z="805.6"/>
 					<rotation yaw="90" pitch="-3.54" roll="180"/>
 				</offset>
 			</connection> -->
 			<!-- L Battery 11 -->
-			<connection name="con_turret_laser_l_25" group="group_keel_mid_battery" tags="turret large standard missile">
+			<connection name="con_turret_laser_l_25" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="560.277"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_26" group="group_keel_mid_battery" tags="turret large standard missile">
+			<!-- <connection name="con_turret_laser_l_26" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="468.416"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<!-- <connection name="con_turret_laser_l_27" group="group_keel_mid_battery" tags="turret large standard missile">
+			<!-- <connection name="con_turret_laser_l_27" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="386.718"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_28" group="group_keel_mid_battery" tags="turret large standard missile">
+			<connection name="con_turret_laser_l_28" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="294.857"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_turret_laser_l_29" group="group_keel_mid_battery" tags="turret large standard missile">
+			<connection name="con_turret_laser_l_29" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="160.244"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_turret_laser_l_30" group="group_keel_mid_battery" tags="turret large standard missile">
+			<!-- <connection name="con_turret_laser_l_30" group="group_keel_mid_battery" tags="turret large standard missile combat">
 				<offset>
 					<position x="0 " y="-63.1234" z="68.3831"/>
 					<rotation yaw="180" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<!-- <connection name="con_shieldgen_038" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<!-- <connection name="con_shieldgen_038" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="19.2141" y="-63.1234" z="513.373"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_039" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<connection name="con_shieldgen_039" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-19.2141" y="-63.1234" z="513.373"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
-			<connection name="con_shieldgen_040" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<connection name="con_shieldgen_040" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="19.2141" y="-63.1234" z="338.368"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_041" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<connection name="con_shieldgen_041" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-19.2141" y="-63.1234" z="338.368"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<!-- <connection name="con_shieldgen_042" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<!-- <connection name="con_shieldgen_042" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="19.2141" y="-63.1234" z="112.947"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_043" group="group_keel_mid_battery" tags="medium shield hittable ">
+			<connection name="con_shieldgen_043" group="group_keel_mid_battery" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-19.2141" y="-63.1234" z="112.947"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection> -->
 			<!-- M Battery 01 Point Defense-->
-			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_001" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-95.02" z="1201"/>
 					<rotation yaw="0" pitch="4.41" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_002" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-133.9" z="-487.7 "/>
 					<rotation yaw="180" pitch="0" roll="180"/> 
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_003" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="96" z="-192.5"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group_point_defense " tags="turret medium standard hittable ">
+			<connection name="con_turret_006" group="group_point_defense " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="96" z="-254.88"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_013" group="group_point_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_013" group="group_point_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="96" z="-170.52"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_044" group="group_point_defense" tags="medium shield hittable ">
+			<connection name="con_shieldgen_044" group="group_point_defense" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="96" z="-224.849"/>
 				</offset>
 			</connection>
 			<!-- M Battery 02 Citadel Defense-->
-			<connection name="con_turret_004" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_004" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="27.2535" y="82.92" z="-222.289"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_005" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="-27.2535" y="82.92" z="-222.289"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_007" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="27.2535" y="82.92" z="-260.639"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_008" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="-27.2535" y="82.92" z="-260.639"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_009" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="27.2535" y="82.92" z="-310.024"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group_citadel_defense " tags="turret medium missile standard hittable ">
+			<connection name="con_turret_010" group="group_citadel_defense " tags="turret medium missile standard hittable combat">
 				<offset>
 					<position x="-27.2535" y="82.92" z="-310.024"/>
 					<rotation yaw="-90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_014" group="group_citadel_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_014" group="group_citadel_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="30.1481" y="82.92" z="-357.93"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_015" group="group_citadel_defense " tags="medium shield hittable ">
+			<connection name="con_shieldgen_015" group="group_citadel_defense " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-30.1481" y="82.92" z="-357.93"/>
 				</offset>
 			</connection>
 			<!-- M Battery 03 Neck Array-->
-			<connection name="con_turret_011" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_011" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="446.806"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_012" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="419.52"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_013" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="384.251"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_014" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="356.965"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_015" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="321.297"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_016" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_016" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="294.011"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_017" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_017" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="258.254"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_018" group="group_neck_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_018" group="group_neck_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="0" y="69.4995" z="230.9691"/>
 					<rotation yaw="180" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_045" group="group_neck_array  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_045" group="group_neck_array  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="69.4995" z="433.181"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_046" group="group_neck_array  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_046" group="group_neck_array  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="69.4995" z="370.627"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_047" group="group_neck_array  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_047" group="group_neck_array  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="69.4995" z="307.672"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_048" group="group_neck_array  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_048" group="group_neck_array  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="69.4995" z="244.63"/>
 					<rotation yaw="90" pitch="0" roll="0"/>
 				</offset>
 			</connection> 
 			<!-- M Battery 04 Bottom Array-->
-			<connection name="con_turret_019" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_019" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="46.6358" y="-63.1234" z="513.351"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_020" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_020" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-46.6358" y="-63.1234" z="513.351"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_021" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_021" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="46.6358" y="-63.1234" z="338.347"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_022" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_022" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-46.6358" y="-63.1234" z="338.347"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_023" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_023" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="46.6358" y="-63.1234" z="229.886"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_024" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_024" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-46.6358" y="-63.1234" z="229.886"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_025" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_025" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="46.6358" y="-63.1234" z="112.925"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_026" group="group_bottom_array " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_026" group="group_bottom_array " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-46.6358" y="-63.1234" z="112.925"/>
 					<rotation yaw="-90" pitch="0" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_049" group="group_bottom_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_049" group="group_bottom_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-63.1234" z="513.351"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_050" group="group_bottom_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_050" group="group_bottom_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-63.1234" z="338.347"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_051" group="group_bottom_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_051" group="group_bottom_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-63.1234" z="229.886"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_052" group="group_bottom_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_052" group="group_bottom_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-63.1234" z="112.925"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Rear Defense -->
-			<connection name="con_turret_027" group="group_engine_defense " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_027" group="group_engine_defense " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="49.9287" y="-93.247" z="-858.107"/>
 					<rotation yaw="0" pitch="180" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_028" group="group_engine_defense  " tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_028" group="group_engine_defense  " tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-49.9287" y="-93.247" z="-858.107"/>
 					<rotation yaw="0" pitch="180" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_053" group="group_engine_defense" tags="medium shield hittable ">
+			<connection name="con_shieldgen_053" group="group_engine_defense" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-93.247" z="-858.107"/>
 					<rotation yaw="90" pitch="0" roll="180"/>
 				</offset>
 			</connection>
 			<!-- M Wing Array -->
-			<connection name="con_turret_029" group="group_wing_array" tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_029" group="group_wing_array" tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="405.557" y="10.2008" z="-457.35"/>
 					<rotation yaw="90" pitch="-2.2" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_030" group="group_wing_array" tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_030" group="group_wing_array" tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-405.557" y="10.2008" z="-457.35"/>
 					<rotation yaw="-90" pitch="-2.2" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_031" group="group_wing_array" tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_031" group="group_wing_array" tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="405.614" y="-6.1445" z="-457.35"/>
 					<rotation yaw="90" pitch="2.2" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_032" group="group_wing_array" tags="turret medium terronly standard hittable ">
+			<connection name="con_turret_032" group="group_wing_array" tags="turret medium terronly standard hittable combat">
 				<offset>
 					<position x="-405.614" y="-6.1445" z="-457.35"/>
 					<rotation yaw="-90" pitch="2.2" roll="-180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_054" group="group_wing_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_054" group="group_wing_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="373.212" y="44.9882" z="-456.996"/>
 					<rotation yaw="90" pitch="90" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_055" group="group_wing_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_055" group="group_wing_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-373.212" y="44.9882" z="-456.996"/>
 					<rotation yaw="-90" pitch="90" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_056" group="group_wing_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_056" group="group_wing_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="373.212" y="-41.111" z="-456.996"/>
 					<rotation yaw="90" pitch="90" roll="0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_057" group="group_wing_array" tags="medium shield hittable ">
+			<connection name="con_shieldgen_057" group="group_wing_array" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-373.212" y="-41.111" z="-456.996"/>
 					<rotation yaw="-90" pitch="90" roll="0"/>
 				</offset>
 			</connection>
 			<!-- L Engines -->
-			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="159.335" y="1.8" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_02" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="53.373" y="-48.99" z="-832.28"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_03" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="86.19" y="13.242" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_04" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="0" y="0.529" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_05" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-157.754" y="1.8" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_06" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_06" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-51.792" y="-48.994" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_07" group="group_back_up_mid " tags="engine large ">
+			<connection name="con_engine_07" group="group_back_up_mid " tags="engine large standard ">
 				<offset>
 					<position x="-84.612" y="13.242" z="-832.283"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_016" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_016" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.9564" y="57.0173" z="-714"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_017" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_017" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-75.9564" y="57.0173" z="-714"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_024" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_024" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.9564" y="57.0173" z="-669.731"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_025" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_025" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-75.9564" y="57.0173" z="-669.731"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_026" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_026" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.9564" y="57.0173" z="-759.786"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_027" group="group_back_up_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_027" group="group_back_up_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-75.9564" y="57.0173" z="-759.786"/>
 				</offset>

--- a/assets/units/size_xl/ship_ter_xl_sapporo.xml
+++ b/assets/units/size_xl/ship_ter_xl_sapporo.xml
@@ -229,43 +229,43 @@
 				</offset>
 			</connection>
 			<!-- L Shields -->
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="0" y="-93.2" z="-611.54"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_03" tags="large shield ">
+			<connection name="con_shieldgenerator_l_03" tags="large shield standard">
 				<offset>
 					<position x="106.171" y="-70.02" z="-528.843"/>
 					<rotation yaw="0" pitch="0" roll="153.4"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_04" tags="large shield ">
+			<connection name="con_shieldgenerator_l_04" tags="large shield standard">
 				<offset>
 					<position x="106.171" y="-70.02" z="-632.599"/>
 					<rotation yaw="0" pitch="0" roll="153.4"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_05" tags="large shield ">
+			<connection name="con_shieldgenerator_l_05" tags="large shield standard">
 				<offset>
 					<position x="-106.171" y="-70.02" z="-632.599"/>
 					<rotation yaw="0" pitch="0" roll="-153.4"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_06" tags="large shield ">
+			<connection name="con_shieldgenerator_l_06" tags="large shield standard">
 				<offset>
 					<position x="-106.171" y="-70.02" z="-528.843"/>
 					<rotation yaw="0" pitch="0" roll="-153.4"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_07" tags="large shield ">
+			<connection name="con_shieldgenerator_l_07" tags="large shield standard">
 				<offset>
 					<position x="32.4936" y="-63.1234" z="-174.89"/>
 					<rotation yaw="0" pitch="0" roll="180"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_08" tags="large shield ">
+			<connection name="con_shieldgenerator_l_08" tags="large shield standard">
 				<offset>
 					<position x="-32.4936" y="-63.1234" z="-174.89"/>
 					<rotation yaw="0" pitch="0" roll="180"/>

--- a/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
@@ -4,38 +4,38 @@
 <add sel="//components/component[@name='ship_xen_xl_destroyer_01']/connections">
 
 <!-- new connections -->
-			<connection name="connection_turret_medium_xe08" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe08" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="10.0048" y="400.227" z="-246.758"/>
 					<rotation yaw="0" pitch="5.13871" roll="-0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe09" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe09" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-10.0048" y="400.227" z="-246.758"/>
 					<rotation yaw="0" pitch="5.13871" roll="0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe10" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe10" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="10.0048" y="400.2627" z="-220.758"/>
 					<rotation yaw="0" pitch="0" roll="-0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe11" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe11" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-10.0048" y="400.627" z="-220.758"/>
 					<rotation yaw="0" pitch="0" roll="0.160101"/>
 				</offset>
 			</connection>
 
-			<connection group="group10" name="con_shieldgen_m_group10_2" tags="medium shield hittable">
+			<connection group="group10" name="con_shieldgen_m_group10_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-59.7573" y="393.5794" z="-220.0033"/>
 					<quaternion qw="-0.9866500290850273" qx="0.001179067484487617" qy="-0.04779913525372811" qz="-0.15567778446322267"/>
 						</offset>
 			</connection>
-			<connection group="group10" name="con_shieldgen_m_group10_1" tags="medium shield hittable">
+			<connection group="group10" name="con_shieldgen_m_group10_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="68.82390000000001" y="390.66040000000004" z="-220.7099"/>
 					<quaternion qw="-0.9876558016438632" qx="-0.003630903861120825" qy="0.01729237543797647" qz="0.15563999411488408"/>
@@ -43,19 +43,19 @@
 			</connection>
 
 
-			<connection group="group11" name="con_shieldgen_m_group11_2" tags="medium shield hittable">
+			<connection group="group11" name="con_shieldgen_m_group11_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-60.0075" y="379.6239" z="-352.703"/>
 					<quaternion qw="-0.9837885050147044" qx="0.11033748584553256" qy="-0.030143444780677736" qz="-0.13812019893909086"/>
 				</offset>
 			</connection>
-			<connection group="group11" name="con_shieldgen_m_group11_1" tags="medium shield hittable">
+			<connection group="group11" name="con_shieldgen_m_group11_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="60.0" y="379.5169" z="-352.3037"/>
 					<quaternion qw="-0.9842502065738893" qx="0.10605588643713461" qy="0.0" qz="0.14143436573651386"/>
 				</offset>
 			</connection>
-			<connection group="group11" name="con_l_turret_group11_1" tags="turret large standard hittable">
+			<connection group="group11" name="con_l_turret_group11_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="0.0" y="384.8639" z="-354.01959999999997"/>
 					<quaternion qw="6.732051033795384e-07" qx="0.0" qy="0.995025757910037" qz="-0.09961797576292687"/>
@@ -250,7 +250,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="connection_turret_large_xe01" group="group02 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe01" group="group02 " tags="turret large standard combat">
 				<offset>
 					<position x="111.5328" y="-301.0975" z="631.3145"/>
 					<quaternion qx="-0.5053" qy="-0.4204242" qz="-0.7051093" qw="0.2659628"/>
@@ -271,7 +271,7 @@
 					<position x="0" y="0" z="-108.8673"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen01" group="group01 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen01" group="group01 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-0.6028414" z="631.2357"/>
 					<quaternion qx="-0.7071068" qy="-3.090862E-08" qz="-0.7071068" qw="1.99496E-07"/>
@@ -282,17 +282,17 @@
 					<position x="0" y="0" z="-34.67276"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe01" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe01" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-37.07291" z="660.7219"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe02" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe02" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-19.87962" y="-37.07291" z="660.7219"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe03" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe03" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="20.01733" y="-37.07291" z="660.7219"/>
 				</offset>
@@ -308,103 +308,103 @@
 					<position x="184.4297" y="-4.419952" z="-17.57288"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen02" group="group02 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen02" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-376.5625" z="419.3069"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe02" group="group02 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe02" group="group02 " tags="turret large standard combat">
 				<offset>
 					<position x="-112.2039" y="-301.0975" z="631.3145"/>
 					<quaternion qx="0.4630568" qy="-0.4046517" qz="-0.733543" qw="-0.2893958"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe03" group="group03 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe03" group="group03 " tags="turret large standard combat">
 				<offset>
 					<position x="-31.98379" y="-41.55704" z="9.102592"/>
 					<quaternion qx="-1" qy="2.279973E-14" qz="3.019916E-07" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe04" group="group03 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe04" group="group03 " tags="turret large standard combat">
 				<offset>
 					<position x="29.59143" y="-41.63035" z="9.102592"/>
 					<quaternion qx="-1" qy="2.279973E-14" qz="3.019916E-07" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen03" group="group03 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen03" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-106.6707" y="-82.59694" z="81.10939"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen04" group="group03 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen04" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="105.5198" y="-82.59694" z="81.10939"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe04" group="group04 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe04" group="group04 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="29.24207" y="66.59866" z="-818.8024"/>
 					<quaternion qx="-1" qy="-1.629207E-07" qz="1.192494E-08" qw="3.894144E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe05" group="group04 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe05" group="group04 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-29.28505" y="66.59866" z="-818.8024"/>
 					<quaternion qx="-1" qy="-1.629207E-07" qz="1.192494E-08" qw="3.894144E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen05" group="group04 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen05" group="group04 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="66.00712" z="-782.598"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe05" group="group05 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe05" group="group05 " tags="turret large standard combat">
 				<offset>
 					<position x="-263.2988" y="21.30472" z="320.1086"/>
 					<quaternion qx="0.6687521" qy="-0.7221637" qz="-0.1221243" qw="0.1278122"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen06" group="group05 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen06" group="group05 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-232.6418" y="63.2319" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen07" group="group06 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen07" group="group06 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="232.7996" y="63.23201" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe06" group="group06 " tags="turret large standard ">
+			<connection name="connection_turret_large_xe06" group="group06 " tags="turret large standard combat">
 				<offset>
 					<position x="263.9633" y="21.30472" z="320.1086"/>
 					<quaternion qx="-0.1211154" qy="0.1345941" qz="0.6689355" qw="-0.7209305"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe06" group="group07 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe06" group="group07 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-122.1165" y="39.79211" z="-392.0824"/>
 					<quaternion qx="-1.643713E-07" qy="-5.099782E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen08" group="group07 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen08" group="group07 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-107.9923" y="40.00399" z="-343.1005"/>
 					<quaternion qx="4.216087E-09" qy="-5.549311E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen09" group="group08 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen09" group="group08 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="107.9682" y="40.00399" z="-343.1005"/>
 					<quaternion qx="-3.371749E-07" qy="3.371746E-07" qz="0.707107" qw="-0.7071065"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe07" group="group08 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe07" group="group08 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="122.1898" y="39.79211" z="-392.0824"/>
 					<quaternion qx="1.236345E-07" qy="-1.236345E-07" qz="0.7071065" qw="-0.707107"/>

--- a/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
@@ -410,13 +410,13 @@
 					<quaternion qx="1.236345E-07" qy="-1.236345E-07" qz="0.7071065" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen_external01" tags="extralarge shield ">
+			<connection name="connection_shieldgen_external01" tags="extralarge shield standard">
 				<offset>
 					<position x="-46.8676" y="-98.32299" z="-424.8965"/>
 					<quaternion qx="-0.9962034" qy="6.384214E-02" qz="-3.693758E-03" qw="-5.907135E-02"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen_external02" tags="extralarge shield ">
+			<connection name="connection_shieldgen_external02" tags="extralarge shield standard">
 				<offset>
 					<position x="47.43003" y="-98.32299" z="-424.8965"/>
 					<quaternion qx="-0.9963008" qy="-6.230363E-02" qz="3.785521E-03" qw="-5.906556E-02"/>

--- a/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_destroyer_01.xml
@@ -256,7 +256,7 @@
 					<quaternion qx="-0.5053" qy="-0.4204242" qz="-0.7051093" qw="0.2659628"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group03 " tags="engine extralarge ">
+			<connection name="con_engine_01" group="group03 " tags="engine extralarge standard">
 				<offset>
 					<position x="-184.7339" y="-4.419952" z="-17.57288"/>
 				</offset>
@@ -303,7 +303,7 @@
 					<quaternion qx="-1" qy="4.371138E-08" qz="-4.37114E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group03 " tags="engine extralarge ">
+			<connection name="con_engine_02" group="group03 " tags="engine extralarge standard">
 				<offset>
 					<position x="184.4297" y="-4.419952" z="-17.57288"/>
 				</offset>

--- a/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
@@ -216,7 +216,7 @@
 					<quaternion qx="-0.5053" qy="-0.4204242" qz="-0.7051093" qw="0.2659628"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group03 " tags="engine extralarge ">
+			<connection name="con_engine_01" group="group03 " tags="engine extralarge standard">
 				<offset>
 					<position x="-184.7339" y="-4.419952" z="-17.57288"/>
 				</offset>
@@ -263,7 +263,7 @@
 					<quaternion qx="-1" qy="4.371138E-08" qz="-4.37114E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group03 " tags="engine extralarge ">
+			<connection name="con_engine_02" group="group03 " tags="engine extralarge standard">
 				<offset>
 					<position x="184.4297" y="-4.419952" z="-17.57288"/>
 				</offset>

--- a/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
@@ -370,13 +370,13 @@
 					<quaternion qx="1.236345E-07" qy="-1.236345E-07" qz="0.7071065" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen_external01" tags="extralarge shield ">
+			<connection name="connection_shieldgen_external01" tags="extralarge shield standard">
 				<offset>
 					<position x="-46.8676" y="-98.32299" z="-424.8965"/>
 					<quaternion qx="-0.9962034" qy="6.384214E-02" qz="-3.693758E-03" qw="-5.907135E-02"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen_external02" tags="extralarge shield ">
+			<connection name="connection_shieldgen_external02" tags="extralarge shield standard">
 				<offset>
 					<position x="47.43003" y="-98.32299" z="-424.8965"/>
 					<quaternion qx="-0.9963008" qy="-6.230363E-02" qz="3.785521E-03" qw="-5.906556E-02"/>

--- a/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
+++ b/assets/units/size_xl/ship_xen_xl_mdestroyer_01.xml
@@ -210,7 +210,7 @@
   			</offset>
 		</connection>
 
-			<connection name="connection_turret_large_xe01" group="group02 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe01" group="group02 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="111.5328" y="-301.0975" z="631.3145"/>
 					<quaternion qx="-0.5053" qy="-0.4204242" qz="-0.7051093" qw="0.2659628"/>
@@ -231,7 +231,7 @@
 					<position x="0" y="0" z="-108.8673"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen01" group="group01 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen01" group="group01 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="1.009996" y="-0.6745749" z="631.2357"/>
 					<quaternion qx="-3.554965E-03" qy="0.7070979" qz="-3.554797E-03" qw="-0.7070978"/>
@@ -242,17 +242,17 @@
 					<position x="0" y="0" z="-34.67276"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe01" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe01" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="0" y="-37.07291" z="660.7219"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe02" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe02" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-19.87962" y="-37.07291" z="660.7219"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe03" group="group01 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe03" group="group01 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="20.01733" y="-37.07291" z="660.7219"/>
 				</offset>
@@ -268,103 +268,103 @@
 					<position x="184.4297" y="-4.419952" z="-17.57288"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen02" group="group02 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen02" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="20.15492" y="-376.9084" z="582.5533"/>
 					<quaternion qx="0.7071067" qy="-1.376788E-07" qz="-0.7071068" qw="-1.99496E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe02" group="group02 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe02" group="group02 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="-112.2039" y="-301.0975" z="631.3145"/>
 					<quaternion qx="0.4630568" qy="-0.4046517" qz="-0.733543" qw="-0.2893958"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe03" group="group09 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe03" group="group09 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="-31.98379" y="-41.55704" z="9.102592"/>
 					<quaternion qx="-1" qy="2.279973E-14" qz="3.019916E-07" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe04" group="group09 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe04" group="group09 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="29.59143" y="-41.63035" z="9.102592"/>
 					<quaternion qx="-1" qy="2.279973E-14" qz="3.019916E-07" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen03" group="group03 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen03" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-106.6707" y="-82.59694" z="81.10939"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen04" group="group03 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen04" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="105.5198" y="-82.59694" z="81.10939"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe04" group="group04 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe04" group="group04 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="29.24207" y="66.59866" z="-818.8024"/>
 					<quaternion qx="-1" qy="-1.629207E-07" qz="1.192494E-08" qw="3.894144E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe05" group="group04 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe05" group="group04 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-29.28505" y="66.59866" z="-818.8024"/>
 					<quaternion qx="-1" qy="-1.629207E-07" qz="1.192494E-08" qw="3.894144E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen05" group="group04 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen05" group="group04 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="66.00712" z="-782.598"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe05" group="group05 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe05" group="group05 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="-263.2988" y="21.30472" z="320.1086"/>
 					<quaternion qx="0.6687521" qy="-0.7221637" qz="-0.1221243" qw="0.1278122"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen06" group="group05 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen06" group="group05 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-227.5337" y="63.2319" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen07" group="group06 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen07" group="group06 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="226.9357" y="63.23201" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_large_xe06" group="group06 " tags="turret large standard xcruise">
+			<connection name="connection_turret_large_xe06" group="group06 " tags="turret large standard xcruise combat">
 				<offset>
 					<position x="263.9633" y="21.30472" z="320.1086"/>
 					<quaternion qx="-0.1211154" qy="0.1345941" qz="0.6689355" qw="-0.7209305"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe06" group="group07 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe06" group="group07 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-122.1165" y="39.79211" z="-392.0824"/>
 					<quaternion qx="-1.643713E-07" qy="-5.099782E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen08" group="group07 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen08" group="group07 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-107.9923" y="40.00399" z="-343.1005"/>
 					<quaternion qx="4.216087E-09" qy="-5.549311E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen09" group="group08 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen09" group="group08 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="107.9682" y="40.00399" z="-343.1005"/>
 					<quaternion qx="-3.371749E-07" qy="3.371746E-07" qz="0.707107" qw="-0.7071065"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe07" group="group08 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe07" group="group08 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="122.1898" y="39.79211" z="-392.0824"/>
 					<quaternion qx="1.236345E-07" qy="-1.236345E-07" qz="0.7071065" qw="-0.707107"/>
@@ -435,93 +435,93 @@
 					<quaternion qx="-0.5" qy="0.5" qz="-0.4999999" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen010" group="group09 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen010" group="group09 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="41.05213" y="-58.78038" z="83.44427"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen011" group="group02 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen011" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="20.15492" y="-376.9084" z="595.6978"/>
 					<quaternion qx="0.7071067" qy="-1.376788E-07" qz="-0.7071068" qw="-1.99496E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen012" group="group02 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen012" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-20.68822" y="-376.9084" z="582.5533"/>
 					<quaternion qx="-0.7071066" qy="-1.99496E-07" qz="-0.7071069" qw="1.376787E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen013" group="group02 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen013" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-20.68823" y="-376.9084" z="595.6978"/>
 					<quaternion qx="-0.7071066" qy="-1.99496E-07" qz="-0.7071069" qw="1.376787E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen014" group="group09 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen014" group="group09 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="27.10046" y="-58.78038" z="83.44427"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen015" group="group09 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen015" group="group09 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-41.6162" y="-58.78038" z="83.44427"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen016" group="group09 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen016" group="group09 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-27.66453" y="-58.78038" z="83.44427"/>
 					<quaternion qx="-1" qy="-4.37114E-08" qz="-4.371138E-08" qw="2.384186E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen017" group="group06 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen017" group="group06 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="238.8788" y="63.23201" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="connection_shieldgen018" group="group05 " tags="medium shield hittable ">
+			<connection name="connection_shieldgen018" group="group05 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-239.4599" y="63.2319" z="245.58"/>
 					<quaternion qx="1.192093E-07" qy="-1" qz="1.942166E-14" qw="-1.629207E-07"/>
 				</offset>
 			</connection>
 
-			<connection name="connection_turret_medium_xe08" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe08" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="10.0048" y="400.227" z="-246.758"/>
 					<rotation yaw="0" pitch="5.13871" roll="-0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe09" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe09" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-10.0048" y="400.227" z="-246.758"/>
 					<rotation yaw="0" pitch="5.13871" roll="0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe10" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe10" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="10.0048" y="400.2627" z="-220.758"/>
 					<rotation yaw="0" pitch="0" roll="-0.160101"/>
 				</offset>
 			</connection>
-			<connection name="connection_turret_medium_xe11" group="group10 " tags="turret medium standard hittable ">
+			<connection name="connection_turret_medium_xe11" group="group10 " tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-10.0048" y="400.627" z="-220.758"/>
 					<rotation yaw="0" pitch="0" roll="0.160101"/>
 				</offset>
 			</connection>
 
-			<connection group="group10" name="con_shieldgen_m_group10_2" tags="medium shield hittable">
+			<connection group="group10" name="con_shieldgen_m_group10_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-59.7573" y="393.5794" z="-220.0033"/>
 					<quaternion qw="-0.9866500290850273" qx="0.001179067484487617" qy="-0.04779913525372811" qz="-0.15567778446322267"/>
 						</offset>
 			</connection>
-			<connection group="group10" name="con_shieldgen_m_group10_1" tags="medium shield hittable">
+			<connection group="group10" name="con_shieldgen_m_group10_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="68.82390000000001" y="390.66040000000004" z="-220.7099"/>
 					<quaternion qw="-0.9876558016438632" qx="-0.003630903861120825" qy="0.01729237543797647" qz="0.15563999411488408"/>
@@ -529,19 +529,19 @@
 			</connection>
 
 
-			<connection group="group12" name="con_shieldgen_m_group12_2" tags="medium shield hittable">
+			<connection group="group12" name="con_shieldgen_m_group12_2" tags="medium shield hittable standard">
 				<offset>
 					<position x="-60.0075" y="379.6239" z="-352.703"/>
 					<quaternion qw="-0.9837885050147044" qx="0.11033748584553256" qy="-0.030143444780677736" qz="-0.13812019893909086"/>
 				</offset>
 			</connection>
-			<connection group="group12" name="con_shieldgen_m_group12_1" tags="medium shield hittable">
+			<connection group="group12" name="con_shieldgen_m_group12_1" tags="medium shield hittable standard">
 				<offset>
 					<position x="60.0" y="379.5169" z="-352.3037"/>
 					<quaternion qw="-0.9842502065738893" qx="0.10605588643713461" qy="0.0" qz="0.14143436573651386"/>
 				</offset>
 			</connection>
-			<connection group="group12" name="con_l_turret_group12_1" tags="turret large standard hittable">
+			<connection group="group12" name="con_l_turret_group12_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="0.0" y="384.8639" z="-354.01959999999997"/>
 					<quaternion qw="6.732051033795384e-07" qx="0.0" qy="0.995025757910037" qz="-0.09961797576292687"/>

--- a/assets/units/size_xl/ship_xen_xl_u.xml
+++ b/assets/units/size_xl/ship_xen_xl_u.xml
@@ -684,7 +684,7 @@
 			</connection>
 
 
-			<connection name="con_engine_01" group="capship_engines " tags="engine extralarge">
+			<connection name="con_engine_01" group="capship_engines " tags="engine extralarge standard">
 				<offset>
 					<position x="0" y="-22.79025" z="-1683.764"/>
 				</offset>

--- a/assets/units/size_xl/ship_xen_xl_u.xml
+++ b/assets/units/size_xl/ship_xen_xl_u.xml
@@ -855,37 +855,37 @@
 					<quaternion qw="-1.0" qx="-0.0" qy="0.0" qz="-0.0"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_5" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_5" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.1987279646816206" qx="-0.007548383561246042" qy="-0.0014063789159163948" qz="0.9800246119651577"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_4" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_4" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.19872600457184242" qx="0.007601303296463366" qy="-0.0016651127257208947" qz="-0.9800241949537359"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_3" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_3" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.9800514761416834" qx="-0.00013892188074821331" qy="8.327363094921513e-05" qz="-0.19874374928213637"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_2" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.6670475835976227" qx="0.005751515005674783" qy="-0.005721714409790457" qz="-0.744970941229203"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_1" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.6670721687331979" qx="-0.0005818394336564022" qy="5.140450822316485e-05" qz="0.7449928727994907"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_6" tags="extralarge shield hittable">
+			<connection name="con_shieldgen_xl_6" tags="extralarge shield hittable standard">
 				<offset>
 					<position x="0" y="0" z="0"/>
 					<quaternion qw="-0.9800514761416834" qx="-0.0001156688794416051" qy="3.160026087837664e-05" qz="0.1987437791092871"/>
@@ -893,73 +893,73 @@
 			</connection>
 		
 
-			<connection group="turrets" name="con_l_turret_turrets_12" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_12" tags="turret large standard hittable combat">
 				<offset>
 					<position x="475.356" y="796.1205" z="-936.9716999999999"/>
 					<quaternion qw="-0.9618536480309424" qx="-0.0" qy="0.0" qz="0.2735645440651402"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_11" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_11" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-475.35619999999994" y="796.1205" z="-936.9716999999999"/>
 					<quaternion qw="-0.9618528273329818" qx="-0.0" qy="0.0" qz="-0.27356742962485325"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_10" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_10" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-930.9770000000001" y="-30.961100000000002" z="-936.9716999999999"/>
 					<quaternion qw="-0.6850048287293202" qx="-0.0" qy="0.0" qz="-0.7285385265155953"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_9" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_9" tags="turret large standard hittable combat">
 				<offset>
 					<position x="930.9768999999999" y="-30.961100000000002" z="-936.9716999999999"/>
 					<quaternion qw="-0.6850066500734958" qx="-0.0" qy="0.0" qz="0.7285368140012467"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_8" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_8" tags="turret large standard hittable combat">
 				<offset>
 					<position x="448.245" y="-843.2397" z="-937.3811"/>
 					<quaternion qw="-0.20780880473402846" qx="-0.0" qy="0.0" qz="0.9781694641906454"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_7" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_7" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-448.2452" y="-843.2397" z="-937.3811"/>
 					<quaternion qw="-0.20780978290338867" qx="-0.0" qy="0.0" qz="-0.9781692563813517"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_6" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_6" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-296.418" y="-824.394" z="115.85049999999998"/>
 					<quaternion qw="-0.20780880473402846" qx="-0.0" qy="0.0" qz="-0.9781694641906454"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_5" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_5" tags="turret large standard hittable combat">
 				<offset>
 					<position x="296.41790000000003" y="-824.394" z="115.85049999999998"/>
 					<quaternion qw="-0.14550246839065187" qx="-0.0" qy="0.0" qz="0.9893578885783584"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_4" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_4" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-828.876" y="-149.98940000000002" z="115.9678"/>
 					<quaternion qw="-0.6447080685092578" qx="-0.0" qy="0.0" qz="-0.7644288759584258"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_3" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_3" tags="turret large standard hittable combat">
 				<offset>
 					<position x="828.8765" y="-149.98940000000002" z="115.7411"/>
 					<quaternion qw="-0.5729681305179435" qx="-0.0" qy="0.0" qz="0.8195776481888539"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_2" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_2" tags="turret large standard hittable combat">
 				<offset>
 					<position x="312.824" y="777.6536" z="114.7038"/>
 					<quaternion qw="-0.9802633732575052" qx="-0.0" qy="0.0" qz="0.19769602689436355"/>
 				</offset>
 			</connection>
-			<connection group="turrets" name="con_l_turret_turrets_1" tags="turret large standard hittable">
+			<connection group="turrets" name="con_l_turret_turrets_1" tags="turret large standard hittable combat">
 				<offset>
 					<position x="-312.8236" y="777.6536" z="114.7038"/>
 					<quaternion qw="-0.9871304753172923" qx="-0.0" qy="0.0" qz="-0.15991693062292262"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
@@ -416,7 +416,7 @@
 					<quaternion qx="-0.5735765" qy="-0.819152" qz="-3.807187E-07" qw="3.205823E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="13.02728" y="-5.156932" z="-221.8337"/>
 					<quaternion qx="2.057111E-07" qy="1.6418E-07" qz="-0.9238796" qw="0.3826832"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
@@ -388,7 +388,7 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_rear_mid_left" tags="engine large ">
+			<connection name="con_engine_01" group="group_rear_mid_left" tags="engine large standard">
 				<offset>
 					<position x="-34.97034" y="-0.2095739" z="-239.288"/>
 				</offset>
@@ -521,7 +521,7 @@
 					<quaternion qx="6.181776E-08" qy="6.181673E-08" qz="-0.7071058" qw="-0.7071077"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_rear_mid_left" tags="engine large ">
+			<connection name="con_engine_02" group="group_rear_mid_left" tags="engine large standard">
 				<offset>
 					<position x="13.00068" y="31.24401" z="-292.9121"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_miner_solid_01.xml
@@ -399,18 +399,18 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_06" group="group_front_mid_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_06" group="group_front_mid_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-35.39799" y="28.30751" z="142.9016"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_02" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_02" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-27.5826" y="-14.96011" z="99.46481"/>
 					<quaternion qx="-8.406123E-09" qy="1.301623E-07" qz="-0.819152" qw="-0.5735765"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_01" group="group_front_mid_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_01" group="group_front_mid_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-17.10662" y="18.70258" z="142.9016"/>
 					<quaternion qx="-0.5735765" qy="-0.819152" qz="-3.807187E-07" qw="3.205823E-08"/>
@@ -437,7 +437,7 @@
 					<position x="2.755553" y="37.13045" z="-168.0753"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_03" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_03" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-23.79064" y="-25.45825" z="99.46481"/>
 					<quaternion qx="-2.426052E-07" qy="3.643615E-07" qz="-0.819152" qw="-0.5735765"/>
@@ -449,73 +449,73 @@
 					<quaternion qx="-8.415194E-09" qy="-5.136959E-07" qz="0.7372773" qw="-0.6755902"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_04" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_04" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="7.197248" y="-43.6114" z="196.1241"/>
 					<quaternion qx="4.608093E-07" qy="-4.608093E-07" qz="0.7071064" qw="-0.7071072"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_05" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_05" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="5.063828" y="-19.69454" z="196.1241"/>
 					<quaternion qx="-1.067702E-07" qy="1.067701E-07" qz="0.7071065" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_05" group="group_front_mid_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_05" group="group_front_mid_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="16.78138" y="10.64947" z="189.2241"/>
 					<quaternion qx="-3.312205E-07" qy="2.047841E-07" qz="0.5258769" qw="-0.8505607"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_04" group="group_mid_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_04" group="group_mid_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-0.542089" y="-74.49456" z="31.46118"/>
 					<quaternion qx="3.88562E-15" qy="3.258414E-07" qz="-1" qw="-1.192488E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_06" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_06" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-0.542089" y="-66.14305" z="50.5748"/>
 					<quaternion qx="-0.7071071" qy="5.33851E-08" qz="0.7071065" qw="-7.024938E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_07" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_07" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-0.542089" y="-66.10314" z="-130.6543"/>
 					<quaternion qx="-0.7071071" qy="5.33851E-08" qz="0.7071065" qw="-7.024938E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_03" group="group_mid_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_03" group="group_mid_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-0.542089" y="-74.48478" z="-111.5101"/>
 					<quaternion qx="-1" qy="-1.192523E-08" qz="-3.139165E-07" qw="1.10467E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_02" group="group_rear_mid_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_02" group="group_rear_mid_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="22.3166" y="53.81767" z="-279.6771"/>
 					<quaternion qx="5.063771E-08" qy="-5.063771E-08" qz="0.1736481" qw="-0.9848077"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_08" group="group_rear_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_08" group="group_rear_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="49.44177" y="31.14167" z="-233.4797"/>
 					<quaternion qx="3.01491E-07" qy="6.463051E-09" qz="0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_01" group="group_rear_mid_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_01" group="group_rear_mid_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="22.37147" y="8.670331" z="-281.1824"/>
 					<quaternion qx="-1.885465E-07" qy="1.885465E-07" qz="-0.985056" qw="0.1722343"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_09" group="group_rear_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_09" group="group_rear_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.59269" y="36.9668" z="-283.1157"/>
 					<quaternion qx="2.298725E-07" qy="2.298719E-07" qz="-0.7071058" qw="-0.7071077"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_10" group="group_rear_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_10" group="group_rear_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.59519" y="25.9668" z="-283.1533"/>
 					<quaternion qx="6.181776E-08" qy="6.181673E-08" qz="-0.7071058" qw="-0.7071077"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
@@ -686,17 +686,17 @@
 					<position x="7.688554" y="7.455887" z="-320.8009"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-58.98767" y="14.53312" z="-441.3755"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-13.97674" y="-43.58201" z="-459.2689"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="6.571976" y="14.80751" z="-462.998"/>
 				</offset>
@@ -819,7 +819,7 @@
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="66.94583" y="-13.52386" z="-429.5649"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
@@ -681,7 +681,7 @@
 					<quaternion qx="-0.6532815" qy="-0.2705981" qz="-0.2705981" qw="-0.6532815"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="7.688554" y="7.455887" z="-320.8009"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scavenger_01.xml
@@ -622,31 +622,31 @@
 					<position x="21.87209" y="31.60526" z="-53.94301"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_02" group="group_front_up_left" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_02" group="group_front_up_left" tags="turret large standard missile combat">
 				<offset>
 					<position x="-55.81881" y="1.016487" z="341.0512"/>
 					<quaternion qx="3.330711E-04" qy="2.30131E-03" qz="-0.1432382" qw="-0.9896855"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_back_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_10" group="group_back_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-41.53257" y="-48.88543" z="-443.3369"/>
 					<quaternion qx="-0.7556058" qy="0.6550267" qz="-4.945314E-08" qw="5.704664E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_09" group="group_mid_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_09" group="group_mid_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-97.66836" y="-14.39394" z="-21.16158"/>
 					<quaternion qx="0.4999981" qy="-0.5000019" qz="-0.4999981" qw="-0.5000019"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_mid_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_mid_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-97.66836" y="-10.37556" z="-40.44608"/>
 					<quaternion qx="1.036598E-06" qy="1.239332E-06" qz="-0.7071067" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.24474" y="-14.6502" z="423.968"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.94272E-07" qw="-6.926099E-07"/>
@@ -707,55 +707,55 @@
 					<quaternion qx="-0.7071068" qy="-8.432163E-09" qz="0.7071068" qw="-8.432163E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_mid_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_mid_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-97.66834" y="-14.67689" z="-58.98018"/>
 					<quaternion qx="0.4999981" qy="-0.5000019" qz="-0.4999981" qw="-0.5000019"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_03" group="group_front_mid_right" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_03" group="group_front_mid_right" tags="turret large standard missile combat">
 				<offset>
 					<position x="52.72398" y="-35.4887" z="341.4023"/>
 					<quaternion qx="-0" qy="-0" qz="-0.976296" qw="0.2164395"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_mid_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_mid_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="23.60335" y="15.45608" z="-207.9943"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="23.60335" y="15.45608" z="-168.9103"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.24474" y="-14.6502" z="441.6567"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.94272E-07" qw="-6.926099E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="13.51358" y="-48.88542" z="-443.3368"/>
 					<quaternion qx="1.801505E-07" qy="-1.561705E-07" qz="0.7556058" qw="-0.6550266"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_down_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_down_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="91.6152" y="-14.23708" z="238.2053"/>
 					<quaternion qx="0.4999795" qy="-0.5000205" qz="-0.4999795" qw="-0.5000205"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_mid_down_right  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_mid_down_right  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="91.6152" y="-20.07599" z="254.5682"/>
 					<quaternion qx="0.7071065" qy="-0.7071071" qz="4.962404E-07" qw="-7.681651E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_mid_down_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_mid_down_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="91.6152" y="-14.23708" z="271.0478"/>
 					<quaternion qx="0.4990119" qy="0.4990113" qz="0.5009868" qw="-0.5009862"/>
@@ -779,12 +779,12 @@
 					<quaternion qx="0.7066967" qy="-0" qz="-0" qw="-0.7075166"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-2.407076" y="41.53378" z="-410.769"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.24474" y="-14.6502" z="459.3456"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
@@ -796,7 +796,7 @@
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-47.02184" y="5.094368" z="401.2124"/>
 					<quaternion qx="-6.953575E-07" qy="-1.593223E-08" qz="-0.1432404" qw="-0.9896879"/>
@@ -807,13 +807,13 @@
 					<position x="-0.470993" y="124.8929" z="66.48956"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_front_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_front_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-37.82983" y="7.752647" z="401.0693"/>
 					<quaternion qx="2.426433E-08" qy="3.511847E-09" qz="-0.1432404" qw="-0.9896879"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="75.24474" y="-14.6502" z="406.098"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
@@ -824,90 +824,90 @@
 					<position x="66.94583" y="-13.52386" z="-429.5649"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="15.57797" y="41.53378" z="-410.769"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_01" group="group_front_mid_right" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_01" group="group_front_mid_right" tags="turret large standard missile combat">
 				<offset>
 					<position x="51.39676" y="4.60916" z="341.5947"/>
 					<quaternion qx="-5.246295E-04" qy="2.265332E-03" qz="0.2256186" qw="-0.9742129"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_04" group="group_mid_down_mid" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_04" group="group_mid_down_mid" tags="turret large standard missile combat">
 				<offset>
 					<position x="-8.402695" y="-49.60527" z="-79.8772"/>
 					<quaternion qx="1.670213E-05" qy="-0.0216039" qz="-0.9997647" qw="-1.936369E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_mid_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_mid_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-97.66835" y="-18.54311" z="-40.40334"/>
 					<quaternion qx="8.826223E-07" qy="1.393308E-06" qz="-0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_mid_down_right  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_mid_down_right  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="91.61519" y="-8.93919" z="254.5682"/>
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="-6.989855E-07" qw="-9.025947E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="13.5027" y="-48.88387" z="-430.1392"/>
 					<quaternion qx="-0.5344858" qy="-0.4629521" qz="0.534112" qw="-0.463384"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-41.52168" y="-48.88387" z="-430.1392"/>
 					<quaternion qx="-0.5344794" qy="0.4629594" qz="-0.5341056" qw="-0.4633912"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="40.41335" y="-35.73086" z="-76.1836"/>
 					<quaternion qx="1.549721E-06" qy="7.152551E-07" qz="-1" qw="4.013404E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="40.93985" y="-35.73086" z="-100.4032"/>
 					<quaternion qx="1.788139E-06" qy="7.152548E-07" qz="-1" qw="5.205499E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="34.75475" y="-38.63921" z="180.6298"/>
 					<quaternion qx="2.821299E-07" qy="1.267591E-06" qz="-1" qw="2.98026E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_17" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_17" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="33.38501" y="-37.34189" z="151.7169"/>
 					<quaternion qx="1.192092E-07" qy="1.66893E-06" qz="-1" qw="4.371159E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_18" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_18" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="33.38501" y="-37.34189" z="135.543"/>
 					<quaternion qx="1.192092E-07" qy="1.66893E-06" qz="-1" qw="4.371159E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="34.62606" y="-38.63921" z="108.3536"/>
 					<quaternion qx="2.821299E-07" qy="1.267591E-06" qz="-1" qw="2.98026E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_19" group="group_mid_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_19" group="group_mid_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="23.68196" y="14.1325" z="-193.9824"/>
 					<quaternion qx="-6.181724E-08" qy="-0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_20" group="group_mid_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_20" group="group_mid_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="23.68196" y="14.1325" z="-183.2363"/>
 					<quaternion qx="-6.181724E-08" qy="-0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
@@ -563,17 +563,17 @@
 					<quaternion qx="0.2126313" qy="0.6743794" qz="0.2126322" qw="-0.6743796"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-123.619" y="7.201774" z="-679.3943"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-97.75413" y="-50.4691" z="-533.3322"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-61.81229" y="-86.96806" z="-564.9327"/>
 				</offset>
@@ -660,7 +660,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="104.4248" y="-43.42821" z="-425.8394"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
@@ -545,19 +545,19 @@
 					<quaternion qx="0.7071068" qy="-0" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_13" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_13" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="85.2584" y="-104.522" z="-309.3823"/>
 					<quaternion qx="-0.7071068" qy="1.143591E-06" qz="-0.7071068" qw="-2.219724E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_12" group="group_back_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_12" group="group_back_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-114.5641" y="14.50947" z="-590.9115"/>
 					<quaternion qx="0.2126313" qy="0.6743794" qz="0.2126322" qw="-0.6743796"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_11" group="group_back_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_11" group="group_back_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-114.5649" y="14.50829" z="-576.9991"/>
 					<quaternion qx="0.2126313" qy="0.6743794" qz="0.2126322" qw="-0.6743796"/>
@@ -578,55 +578,55 @@
 					<position x="-61.81229" y="-86.96806" z="-564.9327"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_10" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_10" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-21.81334" y="-95.4276" z="-497.9116"/>
 					<quaternion qx="2.249457E-06" qy="-1.277466E-06" qz="0.37401" qw="-0.9274247"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_09" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_09" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-21.81334" y="-95.4276" z="-472.7215"/>
 					<quaternion qx="2.160286E-06" qy="-1.056351E-06" qz="0.37401" qw="-0.9274247"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_01" group="group_back_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_01" group="group_back_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-96.74163" y="1.909577" z="-610.0068"/>
 					<quaternion qx="0.2126315" qy="0.6743795" qz="0.2126319" qw="-0.6743796"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_08" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_08" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-96.36038" y="-12.10896" z="-629.7006"/>
 					<quaternion qx="-2.036378E-06" qy="6.540884E-07" qz="-0.887011" qw="0.4617483"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_02" group="group_back_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_02" group="group_back_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-96.76525" y="1.923034" z="-590.6314"/>
 					<quaternion qx="0.2126317" qy="0.6743795" qz="0.2126316" qw="-0.6743796"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_03" group="group_back_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_03" group="group_back_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-96.76524" y="1.923034" z="-568.1922"/>
 					<quaternion qx="0.2126317" qy="0.6743793" qz="0.2126323" qw="-0.6743796"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_m_07" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_m_07" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-38.17422" y="-67.93635" z="-426.5517"/>
 					<quaternion qx="-4.64103E-07" qy="-5.273232E-07" qz="0.7071072" qw="-0.7071063"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_04" group="group_mid_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_04" group="group_mid_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="85.2584" y="-104.522" z="-329.3824"/>
 					<quaternion qx="-0.7071068" qy="8.96322E-07" qz="-0.7071067" qw="-9.131865E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_m_05" group="group_mid_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_m_05" group="group_mid_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="85.2584" y="-104.522" z="-289.3823"/>
 					<quaternion qx="-0.7071068" qy="8.96322E-07" qz="-0.7071067" qw="-9.131865E-07"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_l/ship_pir_l_scrapper_01.xml
@@ -648,7 +648,7 @@
 					<position x="-26.23148" y="50.73955" z="-158.3055"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="-7.488833" y="-97.7634" z="252.2378"/>
 					<quaternion qx="1.123961E-07" qy="1.123964E-07" qz="-0.7071064" qw="-0.7071071"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_m/ship_gen_m_yacht_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_m/ship_gen_m_yacht_01.xml
@@ -3686,7 +3686,7 @@
 					<quaternion qx="-0" qy="0.7071064" qz="-0" qw="-0.7071071"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ship_gen_m_yacht_01 platformcollision mandatory">
+			<connection name="con_engine_01" tags="engine medium ship_gen_m_yacht_01 platformcollision mandatory standard">
 				<offset>
 					<position x="0" y="2.830495" z="-62.97079"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_m/ship_gen_m_yacht_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_m/ship_gen_m_yacht_01.xml
@@ -3614,7 +3614,7 @@
 					<position x="1.251469" y="20.33785" z="6.611723"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable ship_gen_m_yacht_01 mandatory ">
+			<connection name="con_shield_01" tags="medium shield unhittable ship_gen_m_yacht_01 mandatory standard">
 				<offset>
 					<position x="1.251465" y="20.51945" z="15.76168"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
@@ -8,8 +8,8 @@
 			</offset>
 		</connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard highpower missile   </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard highpower missile combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile combat</replace>
 
 </diff>
 <!--
@@ -1021,7 +1021,7 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="2.58138" y="2.476864" z="14.0711"/>
 				</offset>
@@ -1052,7 +1052,7 @@
 					<position x="0" y="10.39113" z="3.692959"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 ">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-3.451322" y="-1.886895" z="-2.503637"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
@@ -1057,7 +1057,7 @@
 					<position x="-3.451322" y="-1.886895" z="-2.503637"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="-1.324755E-02" y="1.680274" z="-4.265256"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_01.xml
@@ -988,7 +988,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-4.771764" y="0.3411317" z="-7.016438"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>
@@ -1026,7 +1026,7 @@
 					<position x="2.58138" y="2.476864" z="14.0711"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="5.506158" y="-0.6926246" z="-5.168375"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
@@ -1291,7 +1291,7 @@
 					<position x="-7.160015" y="-0.8917327" z="7.582635"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="-3.409338E-02" y="2.038136" z="-0.4580679"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
@@ -8,8 +8,8 @@
 			</offset>
 		</connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1 combat</replace>
 
 </diff>
 <!--
@@ -1254,7 +1254,7 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="6.769897" y="0.2290082" z="1.219597"/>
 				</offset>
@@ -1286,7 +1286,7 @@
 					<position x="0" y="10.77266" z="8.239782"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 ">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-7.160015" y="-0.8917327" z="7.582635"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_fighter_02.xml
@@ -1221,7 +1221,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-9.126262" y="3.134513" z="-8.087293"/>
 					<quaternion qx="-0" qy="-0" qz="-0.981568" qw="-0.191113"/>
@@ -1259,7 +1259,7 @@
 					<position x="6.769897" y="0.2290082" z="1.219597"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-7.042599" y="-1.275225" z="-8.087293"/>
 					<quaternion qx="-0" qy="-0" qz="-0.9961947" qw="8.715576E-02"/>
@@ -1314,7 +1314,7 @@
 					<quaternion qx="-0" qy="0.7071065" qz="-0" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" tags="engine small platformcollision ">
+			<connection name="con_engine_03" tags="engine small platformcollision standard">
 				<offset>
 					<position x="10.88125" y="1.171712" z="-3.547703"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7372774" qw="-0.6755902"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
@@ -1010,7 +1010,7 @@
 					<position x="8.246889" y="5.477414" z="7.515118"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-0.6933077" y="4.251648" z="-11.36585"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>
@@ -1048,7 +1048,7 @@
 					<position x="2.936537" y="5.176659" z="-1.495646"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="7.114519" y="5.140356" z="-11.9814"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
@@ -1005,7 +1005,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="8.246889" y="5.477414" z="7.515118"/>
 				</offset>
@@ -1090,13 +1090,13 @@
 					<position x="11.15616" y="4.128" z="-1.572553"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="8.246889" y="4.875904" z="7.515118"/>
 					<quaternion qx="-7.549789E-08" qy="7.549789E-08" qz="-1" qw="-8.742278E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_03" tags="small shield unhittable ">
+			<connection name="con_shield_03" tags="small shield unhittable standard">
 				<offset>
 					<position x="-0.7184858" y="6.093848" z="-8.428978"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_heavyfighter_01.xml
@@ -8,10 +8,10 @@
 			</offset>
 		</connection>
 	</add>
-		<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags">weapon small platformcollision highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags">weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1 </replace>
+		<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags">weapon small platformcollision highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags">weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1 combat</replace>
 
 </diff>
 <!--
@@ -1043,7 +1043,7 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 ">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="2.936537" y="5.176659" z="-1.495646"/>
 				</offset>
@@ -1075,17 +1075,17 @@
 					<position x="0" y="14.16503" z="-1.229022"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 ">
+			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-14.94187" y="1.762496" z="-4.404645"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="11.15616" y="6.127755" z="-1.572553"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 ">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="11.15616" y="4.128" z="-1.572553"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
@@ -960,7 +960,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-10.86274" y="1.0232" z="2.492861"/>
 					<quaternion qx="-0" qy="-0" qz="-0.6755903" qw="-0.7372773"/>
@@ -998,7 +998,7 @@
 					<position x="7.177049" y="-0.9810317" z="13.65229"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="10.86274" y="1.0232" z="2.492861"/>
 					<quaternion qx="-1.877821E-08" qy="2.613192E-08" qz="0.6755901" qw="-0.7372774"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
@@ -1025,7 +1025,7 @@
 					<position x="0" y="10.47978" z="3.713032"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="-1.324755E-02" y="1.717428" z="5.571434"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_s/ship_pir_s_trans_container_01.xml
@@ -993,7 +993,7 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="7.177049" y="-0.9810317" z="13.65229"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
@@ -1063,7 +1063,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 ">
+			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 standard">
 				<offset>
 					<position x="66.96774" y="87.38226" z="-1269.423"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
@@ -1172,13 +1172,13 @@
 					<position x="-99.8172" y="78.53969" z="-1186.681"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 ">
+			<connection name="con_engine_02" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 standard">
 				<offset>
 					<position x="-100.4189" y="4.428649" z="-1196.036"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 ">
+			<connection name="con_engine_03" group="group_back_mid_down" tags="engine extralarge pir_battleship_01 standard">
 				<offset>
 					<position x="-35.60481" y="-117.9177" z="-786.7797"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
@@ -1012,13 +1012,13 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_12" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_12" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="117.4296" y="46.60235" z="166.8687"/>
 					<quaternion qx="6.234515E-07" qy="8.019894E-02" qz="3.770561E-07" qw="-0.9967789"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="86.00674" y="190.0024" z="-1208.147"/>
 					<quaternion qx="5.675795E-07" qy="0.7071066" qz="5.675793E-07" qw="-0.7071069"/>
@@ -1035,7 +1035,7 @@
 					<quaternion qx="0.7071066" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_11" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_11" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="85.90753" y="190.0524" z="-1263.446"/>
 				</offset>
@@ -1045,7 +1045,7 @@
 					<position x="-50" y="103" z="-690"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="35.72434" y="-137.0654" z="-777.4265"/>
 					<quaternion qx="3.060441E-07" qy="-6.522582E-07" qz="0.7933534" qw="-0.6087613"/>
@@ -1069,12 +1069,12 @@
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_10" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="85.90753" y="190.0525" z="-1225.446"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="143.1145" y="86.87064" z="-1257.321"/>
 					<quaternion qx="5.819815E-07" qy="-5.819813E-07" qz="0.7071066" qw="-0.7071069"/>
@@ -1086,13 +1086,13 @@
 					<quaternion qx="-1.109862E-07" qy="1.109862E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_down_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_down_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="62.91805" y="-176.7891" z="-635.4675"/>
 					<quaternion qx="9.395094E-08" qy="-1.178891E-06" qz="0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_09" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_09" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="71.33883" y="-154.9208" z="-628.217"/>
 					<quaternion qx="-3.982377E-07" qy="-1.506489E-06" qz="0.8433914" qw="-0.5372997"/>
@@ -1103,7 +1103,7 @@
 					<position x="2.700806E-02" y="171.948" z="-81.40008"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_front_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_front_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-116.4281" y="-9.248612" z="243.7885"/>
 					<quaternion qx="-0.1235334" qy="-0.6962309" qz="-0.6962339" qw="0.1235333"/>
@@ -1115,7 +1115,7 @@
 					<quaternion qx="-4.853875E-07" qy="4.853875E-07" qz="-0.7071063" qw="-0.7071072"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_back_down_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_back_down_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-145.2508" y="-36.89505" z="-958.6716"/>
 					<quaternion qx="-0.4055791" qy="0.5792271" qz="0.405581" qw="-0.5792283"/>
@@ -1127,7 +1127,7 @@
 					<quaternion qx="-9.417496E-07" qy="4.887623E-07" qz="-1" qw="3.258409E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_back_up_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_back_up_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="117.2429" y="132.044" z="-850.618"/>
 					<quaternion qx="-0.6963632" qy="0.122788" qz="-0.1227879" qw="-0.6963652"/>
@@ -1144,13 +1144,13 @@
 					<position x="34.48273" y="94.54566" z="-193.7445"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_front_top_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_front_top_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="67.11005" y="79.88438" z="-193.5064"/>
 					<quaternion qx="-0.819152" qy="-0.5735765" qz="-7.956812E-07" qw="-9.603079E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="187.9662" y="-5.83664" z="40.94715"/>
 					<quaternion qx="-0.6963634" qy="0.1227883" qz="-0.1227874" qw="-0.6963651"/>
@@ -1162,12 +1162,12 @@
 					<quaternion qx="3.796458E-07" qy="-8.396952E-08" qz="0.7071069" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_large_01" tags="weapon extralarge standard pir_battleship_01 ">
+			<connection name="con_weapon_large_01" tags="weapon extralarge standard pir_battleship_01 combat">
 				<offset>
 					<position x="14.41779" y="-5.83666" z="300.5587"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-99.8172" y="78.53969" z="-1186.681"/>
 				</offset>
@@ -1184,96 +1184,96 @@
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_front_top_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_front_top_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="99.66416" y="46.60232" z="184.0455"/>
 					<quaternion qx="6.367408E-07" qy="0.0801989" qz="6.319435E-08" qw="-0.9967789"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_13" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_13" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="116.0405" y="-58.46732" z="174.5444"/>
 					<quaternion qx="-0.9967789" qy="2.028231E-07" qz="-8.019894E-02" qw="-1.430779E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_front_down_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_front_down_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="101.6678" y="-58.4673" z="172.2172"/>
 					<quaternion qx="-0.9967789" qy="1.07491E-07" qz="-0.0801989" qw="-1.187297E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_14" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_14" group="group_back_up_mid" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="85.90753" y="190.0524" z="-1244.446"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-212.2752" y="3.019415" z="-999.0178"/>
 					<quaternion qx="0.0800473" qy="8.004746E-02" qz="-0.7025613" qw="-0.7025614"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_15" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_15" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="-206.512" y="3.019416" z="-1019.832"/>
 					<quaternion qx="0.0800475" qy="0.0800475" qz="-0.7025613" qw="-0.7025613"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_16" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_16" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="-202.2379" y="3.019415" z="-1038.345"/>
 					<quaternion qx="0.0800475" qy="0.0800475" qz="-0.7025613" qw="-0.7025613"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_17" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable ">
+			<connection name="con_turret_17" group="group_back_mid_left" tags="turret medium standard missile pir_battleship_01 hittable combat">
 				<offset>
 					<position x="-197.9638" y="3.019415" z="-1056.858"/>
 					<quaternion qx="0.0800475" qy="0.0800475" qz="-0.7025613" qw="-0.7025613"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_08" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="71.33883" y="-154.9208" z="-608.217"/>
 					<quaternion qx="-3.982377E-07" qy="-1.506489E-06" qz="0.8433914" qw="-0.5372997"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_07" group="group_back_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="71.33883" y="-154.9208" z="-648.217"/>
 					<quaternion qx="-1.06326E-07" qy="-1.214577E-06" qz="0.8433914" qw="-0.5372997"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_06" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="119.2381" y="-58.46736" z="154.8017"/>
 					<quaternion qx="-0.9967789" qy="2.028231E-07" qz="-8.019894E-02" qw="-1.430779E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_05" group="group_front_down_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="112.8428" y="-58.46727" z="194.2872"/>
 					<quaternion qx="-0.9967789" qy="2.028231E-07" qz="-8.019894E-02" qw="-1.430779E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_04" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="120.9077" y="46.60231" z="147.1715"/>
 					<quaternion qx="6.234515E-07" qy="8.019894E-02" qz="3.770561E-07" qw="-0.9967789"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_03" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="113.9618" y="46.60237" z="186.5638"/>
 					<quaternion qx="6.234515E-07" qy="8.019894E-02" qz="3.770561E-07" qw="-0.9967789"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_02" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="110.9719" y="46.60241" z="206.3382"/>
 					<quaternion qx="6.234515E-07" qy="8.019894E-02" qz="3.770561E-07" qw="-0.9967789"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable ">
+			<connection name="con_turret_01" group="group_front_top_right" tags="turret medium pir_battleship_01 hittable combat">
 				<offset>
 					<position x="107.4555" y="46.60243" z="226.0273"/>
 					<quaternion qx="6.234515E-07" qy="8.019894E-02" qz="3.770561E-07" qw="-0.9967789"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01.xml
@@ -1080,7 +1080,7 @@
 					<quaternion qx="5.819815E-07" qy="-5.819813E-07" qz="0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield pir_battleship_01 ">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield pir_battleship_01 standard">
 				<offset>
 					<position x="-140.7015" y="-1.192383" z="-686.0048"/>
 					<quaternion qx="-1.109862E-07" qy="1.109862E-07" qz="-0.7071068" qw="-0.7071068"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
@@ -624,31 +624,31 @@
 					<position x="65.61627" y="90.59657" z="-156.3975"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_02" group="group_front_up_left" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_02" group="group_front_up_left" tags="turret large standard missile combat">
 				<offset>
 					<position x="-167.4564" y="3.049461" z="1023.154"/>
 					<quaternion qx="3.330711E-04" qy="2.30131E-03" qz="-0.1432382" qw="-0.9896855"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_back_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_10" group="group_back_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-124.5977" y="-146.6563" z="-1330.011"/>
 					<quaternion qx="-0.7556058" qy="0.6550267" qz="-4.945314E-08" qw="5.704664E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_09" group="group_mid_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_09" group="group_mid_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-293.0051" y="-43.18182" z="-63.48473"/>
 					<quaternion qx="0.4999981" qy="-0.5000019" qz="-0.4999981" qw="-0.5000019"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_mid_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_mid_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-293.0051" y="-31.12668" z="-121.3382"/>
 					<quaternion qx="1.036598E-06" qy="1.239332E-06" qz="-0.7071067" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="225.7342" y="-43.9506" z="1271.904"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.94272E-07" qw="-6.926099E-07"/>
@@ -709,55 +709,55 @@
 					<quaternion qx="-0.7071068" qy="-8.432163E-09" qz="0.7071068" qw="-8.432163E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_mid_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_mid_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-293.005" y="-44.03067" z="-176.9405"/>
 					<quaternion qx="0.4999981" qy="-0.5000019" qz="-0.4999981" qw="-0.5000019"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_03" group="group_front_mid_right" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_03" group="group_front_mid_right" tags="turret large standard missile combat">
 				<offset>
 					<position x="158.1719" y="-106.4661" z="1024.207"/>
 					<quaternion qx="-0" qy="-0" qz="-0.976296" qw="0.2164395"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_mid_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_mid_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="70.81004" y="46.36823" z="-623.983"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="70.81004" y="46.36823" z="-506.731"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="225.7342" y="-43.9506" z="1324.97"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.94272E-07" qw="-6.926099E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="40.54075" y="-146.6563" z="-1330.01"/>
 					<quaternion qx="1.801505E-07" qy="-1.561705E-07" qz="0.7556058" qw="-0.6550266"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_down_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_down_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="274.8456" y="-42.71124" z="714.6158"/>
 					<quaternion qx="0.4999795" qy="-0.5000205" qz="-0.4999795" qw="-0.5000205"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_mid_down_right  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_mid_down_right  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="274.8456" y="-60.22798" z="763.7045"/>
 					<quaternion qx="0.7071065" qy="-0.7071071" qz="4.962404E-07" qw="-7.681651E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_mid_down_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_mid_down_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="274.8456" y="-42.71124" z="813.1434"/>
 					<quaternion qx="0.4990119" qy="0.4990113" qz="0.5009868" qw="-0.5009862"/>
@@ -781,12 +781,12 @@
 					<quaternion qx="0.7066967" qy="-0" qz="-0" qw="-0.7075166"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-7.221227" y="124.6013" z="-1232.307"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="225.7342" y="-43.95059" z="1378.037"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
@@ -798,7 +798,7 @@
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-141.0655" y="15.2831" z="1203.637"/>
 					<quaternion qx="-6.953575E-07" qy="-1.593223E-08" qz="-0.1432404" qw="-0.9896879"/>
@@ -809,13 +809,13 @@
 					<position x="-1.412979" y="374.6787" z="199.4687"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_front_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_front_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-113.4895" y="23.25794" z="1203.208"/>
 					<quaternion qx="2.426433E-08" qy="3.511847E-09" qz="-0.1432404" qw="-0.9896879"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_front_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_front_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="225.7342" y="-43.95059" z="1218.294"/>
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
@@ -826,90 +826,90 @@
 					<position x="200.8375" y="-40.57159" z="-1288.695"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="46.73391" y="124.6013" z="-1232.307"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_01" group="group_front_mid_right" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_01" group="group_front_mid_right" tags="turret large standard missile combat">
 				<offset>
 					<position x="154.1903" y="13.82748" z="1024.784"/>
 					<quaternion qx="-5.246295E-04" qy="2.265332E-03" qz="0.2256186" qw="-0.9742129"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_04" group="group_mid_down_mid" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_04" group="group_mid_down_mid" tags="turret large standard missile combat">
 				<offset>
 					<position x="-25.20808" y="-148.8158" z="-239.6316"/>
 					<quaternion qx="1.670213E-05" qy="-0.0216039" qz="-0.9997647" qw="-1.936369E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_mid_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_mid_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-293.0051" y="-55.62934" z="-121.21"/>
 					<quaternion qx="8.826223E-07" qy="1.393308E-06" qz="-0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_mid_down_right  " tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_mid_down_right  " tags="medium shield hittable standard ">
 				<offset>
 					<position x="274.8456" y="-26.81757" z="763.7045"/>
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="-6.989855E-07" qw="-9.025947E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="40.50809" y="-146.6516" z="-1290.418"/>
 					<quaternion qx="-0.5344858" qy="-0.4629521" qz="0.534112" qw="-0.463384"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-124.565" y="-146.6516" z="-1290.418"/>
 					<quaternion qx="-0.5344794" qy="0.4629594" qz="-0.5341056" qw="-0.4633912"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="121.2401" y="-107.1926" z="-228.5508"/>
 					<quaternion qx="1.549721E-06" qy="7.152551E-07" qz="-1" qw="4.013404E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="122.8195" y="-107.1926" z="-301.2097"/>
 					<quaternion qx="1.788139E-06" qy="7.152548E-07" qz="-1" qw="5.205499E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="104.2643" y="-115.9176" z="541.8894"/>
 					<quaternion qx="2.821299E-07" qy="1.267591E-06" qz="-1" qw="2.98026E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_17" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_17" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="100.155" y="-112.0257" z="455.1508"/>
 					<quaternion qx="1.192092E-07" qy="1.66893E-06" qz="-1" qw="4.371159E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_18" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_18" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="100.155" y="-112.0257" z="406.629"/>
 					<quaternion qx="1.192092E-07" qy="1.66893E-06" qz="-1" qw="4.371159E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="103.8782" y="-115.9176" z="325.0607"/>
 					<quaternion qx="2.821299E-07" qy="1.267591E-06" qz="-1" qw="2.98026E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_19" group="group_mid_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_19" group="group_mid_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="71.04588" y="42.39751" z="-581.9471"/>
 					<quaternion qx="-6.181724E-08" qy="-0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_20" group="group_mid_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_20" group="group_mid_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="71.04588" y="42.39751" z="-549.7089"/>
 					<quaternion qx="-6.181724E-08" qy="-0.7071068" qz="-6.181723E-08" qw="-0.7071067"/>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
@@ -683,7 +683,7 @@
 					<quaternion qx="-0.6532815" qy="-0.2705981" qz="-0.2705981" qw="-0.6532815"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgenerator_l_01" tags="large shield ">
+			<connection name="con_shieldgenerator_l_01" tags="large shield standard">
 				<offset>
 					<position x="23.06566" y="22.36766" z="-962.4027"/>
 				</offset>

--- a/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
+++ b/extensions/ego_dlc_pirate/assets/units/size_xl/ship_pir_xl_battleship_01_a.xml
@@ -688,17 +688,17 @@
 					<position x="23.06566" y="22.36766" z="-962.4027"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-176.963" y="43.59936" z="-1324.126"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-41.93021" y="-130.746" z="-1377.807"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_03" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="19.71593" y="44.42253" z="-1388.994"/>
 				</offset>
@@ -821,7 +821,7 @@
 					<quaternion qx="-0.7071068" qy="-0.7071068" qz="-5.106039E-07" qw="-6.062876E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_04" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="200.8375" y="-40.57159" z="-1288.695"/>
 				</offset>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_m_gatling_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_m_gatling_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard  ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_m_sticky_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_m_sticky_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard  ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_s_gatling_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_s_gatling_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon small standard  ">
+	<connection name="WeaponCon_01" tags="component weapon small standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_s_sticky_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/heavy/weapon_spl_s_sticky_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon small standard  ">
+	<connection name="WeaponCon_01" tags="component weapon small standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/standard/weapon_spl_m_shotgun_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/standard/weapon_spl_m_shotgun_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/props/WeaponSystems/standard/weapon_spl_s_shotgun_01_mk1.xml
+++ b/extensions/ego_dlc_split/assets/props/WeaponSystems/standard/weapon_spl_s_shotgun_01_mk1.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon small standard ">
+	<connection name="WeaponCon_01" tags="component weapon small standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_split/assets/structures/defence/defence_spl_disc_01.xml
+++ b/extensions/ego_dlc_split/assets/structures/defence/defence_spl_disc_01.xml
@@ -607,37 +607,37 @@
 					<quaternion qx="-0.7303984" qy="0.4653152" qz="-0.4216957" qw="0.2686498"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group11" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group11" tags="large shield standard">
 				<offset>
 					<position x="61.69086" y="-0.1529846" z="-179.5629"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group12" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group12" tags="large shield standard">
 				<offset>
 					<position x="186.4018" y="-0.1529822" z="36.26831"/>
 					<quaternion qx="-0.6123725" qy="-0.6123725" qz="0.3535532" qw="0.3535535"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group07" tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group07" tags="large shield standard">
 				<offset>
 					<position x="124.6606" y="-0.1529822" z="143.2073"/>
 					<quaternion qx="-0.6123725" qy="0.6123724" qz="0.3535533" qw="-0.3535534"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group08" tags="large shield ">
+			<connection name="con_shieldgen_large_004" group="group08" tags="large shield standard">
 				<offset>
 					<position x="-124.6102" y="-0.1529822" z="143.2946"/>
 					<quaternion qx="-0.6123725" qy="-0.6123725" qz="-0.3535532" qw="-0.3535535"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_005" group="group09" tags="large shield ">
+			<connection name="con_shieldgen_large_005" group="group09" tags="large shield standard">
 				<offset>
 					<position x="-186.3515" y="-0.1529822" z="36.35553"/>
 					<quaternion qx="-0.6123725" qy="0.6123723" qz="-0.3535534" qw="0.3535535"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_006" group="group10" tags="large shield ">
+			<connection name="con_shieldgen_large_006" group="group10" tags="large shield standard">
 				<offset>
 					<position x="-61.79166" y="-0.1529822" z="-179.5629"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>

--- a/extensions/ego_dlc_split/assets/structures/defence/defence_spl_disc_01.xml
+++ b/extensions/ego_dlc_split/assets/structures/defence/defence_spl_disc_01.xml
@@ -8,73 +8,73 @@
 	<remove sel="//components/component/connections/connection[@name='con_turret_large_011']"/>
 </diff>
 
-<!-- 			<connection name="con_turret_large_011" group="group11" tags="turret large standard missile ">
+<!-- 			<connection name="con_turret_large_011" group="group11" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="86.9538" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.5372996" qw="-0.8433914"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_010" group="group11" tags="turret large standard missile ">
+			<connection name="con_turret_large_010" group="group11" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.94394" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_009" group="group10" tags="turret large standard missile ">
+			<connection name="con_turret_large_009" group="group10" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90027" y="86.94394" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.5372995" qw="-0.8433915"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_008" group="group10" tags="turret large standard missile ">
+			<connection name="con_turret_large_008" group="group10" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.9003" y="-86.95379" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_007" group="group12" tags="turret large standard missile ">
+			<connection name="con_turret_large_007" group="group12" tags="turret large standard missile combat">
 				<offset>
 					<position x="235.6254" y="86.94394" z="65.71684"/>
 					<quaternion qx="-0.465315" qy="-0.7303985" qz="0.2686498" qw="0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_006" group="group12" tags="turret large standard missile ">
+			<connection name="con_turret_large_006" group="group12" tags="turret large standard missile combat">
 				<offset>
 					<position x="235.6254" y="-86.95379" z="65.71681"/>
 					<quaternion qx="-0.7303984" qy="-0.465315" qz="0.4216958" qw="0.2686498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_005" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_005" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="174.7251" y="86.9538" z="171.1992"/>
 					<quaternion qx="0.4653151" qy="-0.7303983" qz="-0.2686498" qw="0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_004" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_004" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="174.7251" y="-86.94394" z="171.1992"/>
 					<quaternion qx="-0.7303984" qy="0.465315" qz="0.4216958" qw="-0.2686498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_003" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_003" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-174.7252" y="86.94394" z="171.1991"/>
 					<quaternion qx="-0.465315" qy="-0.7303985" qz="-0.2686498" qw="-0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_002" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_002" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-174.7252" y="-86.95379" z="171.1992"/>
 					<quaternion qx="-0.7303984" qy="-0.4653152" qz="-0.4216956" qw="-0.2686497"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_001" group="group09" tags="turret large standard missile ">
+			<connection name="con_turret_large_001" group="group09" tags="turret large standard missile combat">
 				<offset>
 					<position x="-235.6254" y="86.9538" z="65.71675"/>
 					<quaternion qx="0.4653151" qy="-0.7303984" qz="0.2686498" qw="-0.4216957"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_012" group="group09" tags="turret large standard missile ">
+			<connection name="con_turret_large_012" group="group09" tags="turret large standard missile combat">
 				<offset>
 					<position x="-235.6254" y="-86.94394" z="65.71675"/>
 					<quaternion qx="-0.7303984" qy="0.4653152" qz="-0.4216957" qw="0.2686498"/>
@@ -429,179 +429,179 @@
 					<quaternion qx="-0" qy="-0.5000002" qz="-0" qw="-0.8660253"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="183.8337" z="-144.9635"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_011" group="group11" tags="turret large standard missile ">
+			<connection name="con_turret_large_011" group="group11" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="86.9538" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.5372996" qw="-0.8433914"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="183.8665" z="-168.9518"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="183.8665" z="-121.7714"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.207966E-06" y="-183.9386" z="-168.9518"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.207966E-06" y="-183.9386" z="-121.7714"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="105.4572" y="-183.9386" z="60.88573"/>
 					<quaternion qx="-0.8660254" qy="6.538309E-08" qz="0.5000001" qw="-3.774895E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="146.3166" y="-183.9386" z="84.47594"/>
 					<quaternion qx="-0.5" qy="2.185569E-08" qz="-0.8660254" qw="3.785517E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="105.4572" y="183.8665" z="60.88573"/>
 					<quaternion qx="-0" qy="-0.8660254" qz="-0" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="146.3166" y="183.8665" z="84.47594"/>
 					<quaternion qx="-0" qy="-0.5" qz="-0" qw="-0.8660254"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-105.4572" y="-183.9386" z="60.8857"/>
 					<quaternion qx="-0.8660254" qy="6.538309E-08" qz="-0.5" qw="3.774895E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-146.3166" y="-183.9386" z="84.47589"/>
 					<quaternion qx="0.5000002" qy="-2.18557E-08" qz="-0.8660253" qw="3.785516E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_011" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-105.4572" y="183.8665" z="60.8857"/>
 					<quaternion qx="-0" qy="-0.8660254" qz="-0" qw="-0.5000001"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_012" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-146.3166" y="183.8665" z="84.47589"/>
 					<quaternion qx="-0" qy="0.5000002" qz="-0" qw="-0.8660253"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group04" tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group04" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.670288E-05" y="-183.8932" z="-144.9635"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group06" tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group06" tags="medium shield hittable standard ">
 				<offset>
 					<position x="125.5421" y="-183.8932" z="72.48181"/>
 					<quaternion qx="-0.8660254" qy="6.538309E-08" qz="0.5000001" qw="-3.774895E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group02" tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group02" tags="medium shield hittable standard ">
 				<offset>
 					<position x="125.5421" y="183.9102" z="72.48178"/>
 					<quaternion qx="-0" qy="-0.8660254" qz="-0" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group05" tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group05" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-125.5421" y="-183.8932" z="72.48172"/>
 					<quaternion qx="-0.8660254" qy="6.538309E-08" qz="-0.5" qw="3.774895E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group03" tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group03" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-125.5421" y="183.9188" z="72.48175"/>
 					<quaternion qx="-0" qy="-0.8660254" qz="-0" qw="-0.5000001"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_010" group="group11" tags="turret large standard missile ">
+			<connection name="con_turret_large_010" group="group11" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.94394" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_009" group="group10" tags="turret large standard missile ">
+			<connection name="con_turret_large_009" group="group10" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90027" y="86.94394" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.5372995" qw="-0.8433915"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_008" group="group10" tags="turret large standard missile ">
+			<connection name="con_turret_large_008" group="group10" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.9003" y="-86.95379" z="-236.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_007" group="group12" tags="turret large standard missile ">
+			<connection name="con_turret_large_007" group="group12" tags="turret large standard missile combat">
 				<offset>
 					<position x="235.6254" y="86.94394" z="65.71684"/>
 					<quaternion qx="-0.465315" qy="-0.7303985" qz="0.2686498" qw="0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_006" group="group12" tags="turret large standard missile ">
+			<connection name="con_turret_large_006" group="group12" tags="turret large standard missile combat">
 				<offset>
 					<position x="235.6254" y="-86.95379" z="65.71681"/>
 					<quaternion qx="-0.7303984" qy="-0.465315" qz="0.4216958" qw="0.2686498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_005" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_005" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="174.7251" y="86.9538" z="171.1992"/>
 					<quaternion qx="0.4653151" qy="-0.7303983" qz="-0.2686498" qw="0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_004" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_004" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="174.7251" y="-86.94394" z="171.1992"/>
 					<quaternion qx="-0.7303984" qy="0.465315" qz="0.4216958" qw="-0.2686498"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_003" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_003" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-174.7252" y="86.94394" z="171.1991"/>
 					<quaternion qx="-0.465315" qy="-0.7303985" qz="-0.2686498" qw="-0.4216958"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_002" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_002" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-174.7252" y="-86.95379" z="171.1992"/>
 					<quaternion qx="-0.7303984" qy="-0.4653152" qz="-0.4216956" qw="-0.2686497"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_001" group="group09" tags="turret large standard missile ">
+			<connection name="con_turret_large_001" group="group09" tags="turret large standard missile combat">
 				<offset>
 					<position x="-235.6254" y="86.9538" z="65.71675"/>
 					<quaternion qx="0.4653151" qy="-0.7303984" qz="0.2686498" qw="-0.4216957"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_012" group="group09" tags="turret large standard missile ">
+			<connection name="con_turret_large_012" group="group09" tags="turret large standard missile combat">
 				<offset>
 					<position x="-235.6254" y="-86.94394" z="65.71675"/>
 					<quaternion qx="-0.7303984" qy="0.4653152" qz="-0.4216957" qw="0.2686498"/>

--- a/extensions/ego_dlc_split/assets/structures/defence/defence_spl_tube_01.xml
+++ b/extensions/ego_dlc_split/assets/structures/defence/defence_spl_tube_01.xml
@@ -397,13 +397,13 @@
 					<quaternion qx="-0" qy="-0" qz="-0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group06" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group06" tags="large shield standard">
 				<offset>
 					<position x="61.69086" y="-0.1529846" z="-79.56287"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071066" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_006" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_006" group="group05" tags="large shield standard">
 				<offset>
 					<position x="-61.79166" y="-0.1529822" z="-79.56287"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
@@ -414,7 +414,7 @@
 					<position x="-3.433228E-05" y="0" z="200"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_007" group="group08" tags="large shield ">
+			<connection name="con_shieldgen_large_007" group="group08" tags="large shield standard">
 				<offset>
 					<position x="-61.69089" y="-0.1529846" z="79.56285"/>
 					<quaternion qx="-0.7071069" qy="0.7071066" qz="-5.338507E-08" qw="5.338509E-08"/>
@@ -438,7 +438,7 @@
 					<quaternion qx="-0.8433915" qy="-0.5372996" qz="-6.367429E-08" qw="-4.056499E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_008" group="group07" tags="large shield ">
+			<connection name="con_shieldgen_large_008" group="group07" tags="large shield standard">
 				<offset>
 					<position x="61.79165" y="-0.1529822" z="79.56287"/>
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="-5.338509E-08" qw="-5.338508E-08"/>

--- a/extensions/ego_dlc_split/assets/structures/defence/defence_spl_tube_01.xml
+++ b/extensions/ego_dlc_split/assets/structures/defence/defence_spl_tube_01.xml
@@ -5,25 +5,25 @@
 	<remove sel="//components/component/connections/connection[@name='con_turret_large_008']"/>
 	<remove sel="//components/component/connections/connection[@name='con_turret_large_015']"/>
 </diff>
-<!-- 			<connection name="con_turret_large_011" group="group06" tags="turret large standard missile ">
+<!-- 			<connection name="con_turret_large_011" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="86.9538" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.5372996" qw="-0.8433914"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_010" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_large_010" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.94394" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_009" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_large_009" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90027" y="86.94394" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.5372995" qw="-0.8433915"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_008" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_large_008" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.9003" y="-86.95379" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.8433915" qw="-0.5372996"/>
@@ -31,26 +31,26 @@
 			</connection>
 
 
-			<connection name="con_turret_large_012" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_012" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90031" y="-86.94394" z="136.9159"/>
 					<quaternion qx="-0.8433914" qy="0.5372997" qz="-6.367428E-08" qw="4.056499E-08"/>
 				</offset>
 			</connection>
-						<connection name="con_turret_large_015" group="group08" tags="turret large standard missile ">
+						<connection name="con_turret_large_015" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90031" y="86.9538" z="136.9159"/>
 					<quaternion qx="0.5372996" qy="-0.8433914" qz="4.056499E-08" qw="-6.367428E-08"/>
 				</offset>
 			</connection>
 
-			<connection name="con_turret_large_013" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_013" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90025" y="86.94394" z="136.916"/>
 					<quaternion qx="-0.5372998" qy="-0.8433914" qz="-4.0565E-08" qw="-6.367428E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_014" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_014" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.95379" z="136.916"/>
 					<quaternion qx="-0.8433915" qy="-0.5372996" qz="-6.367429E-08" qw="-4.056499E-08"/>
@@ -373,25 +373,25 @@
 					<position x="2.472717" y="192.3793" z="-0.4358521"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_011" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_large_011" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="86.9538" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.5372996" qw="-0.8433914"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_010" group="group06" tags="turret large standard missile ">
+			<connection name="con_turret_large_010" group="group06" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.94394" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="0.8433915" qw="-0.5372996"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_009" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_large_009" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90027" y="86.94394" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.5372995" qw="-0.8433915"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_008" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_large_008" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.9003" y="-86.95379" z="-136.916"/>
 					<quaternion qx="-0" qy="-0" qz="-0.8433915" qw="-0.5372996"/>
@@ -420,19 +420,19 @@
 					<quaternion qx="-0.7071069" qy="0.7071066" qz="-5.338507E-08" qw="5.338509E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_012" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_012" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90031" y="-86.94394" z="136.9159"/>
 					<quaternion qx="-0.8433914" qy="0.5372997" qz="-6.367428E-08" qw="4.056499E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_013" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_013" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90025" y="86.94394" z="136.916"/>
 					<quaternion qx="-0.5372998" qy="-0.8433914" qz="-4.0565E-08" qw="-6.367428E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_014" group="group07" tags="turret large standard missile ">
+			<connection name="con_turret_large_014" group="group07" tags="turret large standard missile combat">
 				<offset>
 					<position x="60.90028" y="-86.95379" z="136.916"/>
 					<quaternion qx="-0.8433915" qy="-0.5372996" qz="-6.367429E-08" qw="-4.056499E-08"/>
@@ -444,76 +444,76 @@
 					<quaternion qx="-0.7071067" qy="-0.7071068" qz="-5.338509E-08" qw="-5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_015" group="group08" tags="turret large standard missile ">
+			<connection name="con_turret_large_015" group="group08" tags="turret large standard missile combat">
 				<offset>
 					<position x="-60.90031" y="86.9538" z="136.9159"/>
 					<quaternion qx="0.5372996" qy="-0.8433914" qz="4.056499E-08" qw="-6.367428E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="183.763" z="-44.96353"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="183.999" z="-68.95183"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="183.999" z="-21.77144"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.207966E-06" y="-183.999" z="-68.95183"/>
 					<quaternion qx="-1" qy="4.371139E-08" qz="-4.371139E-08" qw="1.910685E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group04" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group04" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.207966E-06" y="-183.999" z="-21.77144"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group04" tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group04" tags="medium shield hittable standard ">
 				<offset>
 					<position x="2.670288E-05" y="-183.763" z="-44.96353"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group02" tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group02" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.335144E-05" y="183.763" z="44.96354"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.525879E-05" y="183.999" z="68.95184"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-9.536743E-06" y="183.999" z="21.77145"/>
 					<quaternion qx="-0" qy="-1" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.335144E-05" y="-183.999" z="68.95184"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-8.583069E-06" y="-183.999" z="21.77145"/>
 					<quaternion qx="-1" qy="7.54979E-08" qz="-7.54979E-08" qw="5.699933E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group03" tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group03" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-4.005432E-05" y="-183.763" z="44.96355"/>
 					<quaternion qx="-1" qy="7.54979E-08" qz="-7.54979E-08" qw="5.699933E-15"/>

--- a/extensions/ego_dlc_split/assets/units/size_l/ship_spl_l_destroyer_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_l/ship_spl_l_destroyer_01.xml
@@ -11,7 +11,7 @@
 
 
 		<replace sel="//components/component/connections/connection[@name='con_turret_laser_l_06']">
-			<connection name="con_turret_laser_m_bottom_1" group="group_down_back_mid" tags="turret medium standard hittable ">
+			<connection name="con_turret_laser_m_bottom_1" group="group_down_back_mid" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="9.25" y="-60.14512" z="-109.4115"/>
 					<quaternion qx="-0.9990482" qy="4.176312E-08" qz="-4.557646E-08" qw="4.361954E-02"/>
@@ -20,7 +20,7 @@
 		</replace>
 
 		<add sel="//components/component/connections">
-			<connection name="con_turret_laser_m_bottom_2" group="group_down_back_mid" tags="turret medium standard hittable ">
+			<connection name="con_turret_laser_m_bottom_2" group="group_down_back_mid" tags="turret medium standard hittable combat">
 				<offset>
 					<position x="-9.25" y="-60.14512" z="-109.4115"/>
 					<quaternion qx="-0.9990482" qy="4.176312E-08" qz="-4.557646E-08" qw="4.361954E-02"/>

--- a/extensions/ego_dlc_split/assets/units/size_l/ship_spl_l_destroyer_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_l/ship_spl_l_destroyer_01.xml
@@ -29,7 +29,7 @@
 		   </add>
 
 		<replace sel="//components/component/connections/connection[@name='con_turret_laser_l_03']">
-			<connection name="con_shieldgenerator_l_02" tags="large shield ">
+			<connection name="con_shieldgenerator_l_02" tags="large shield standard">
 				<offset>
 					<position x="-6.054954E-16" y="46.29222" z="-114.6027"/>
 					<quaternion qx="4.361942E-02" qy="4.176312E-08" qz="4.557645E-08" qw="-0.9990482"/>

--- a/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_corvette_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_corvette_01.xml
@@ -7,10 +7,10 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium missile platformcollision symmetry symmetry_left symmetry_1 highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_06']/@tags"> weapon medium missile platformcollision symmetry symmetry_right symmetry_1 highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_3  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_05']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_3  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium missile platformcollision symmetry symmetry_left symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_06']/@tags"> weapon medium missile platformcollision symmetry symmetry_right symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_3 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_05']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_3 combat</replace>
 </diff>

--- a/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_frigate_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_frigate_01.xml
@@ -7,7 +7,7 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right highpower</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right highpower combat</replace>
 </diff>

--- a/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_miner_solid_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_m/ship_spl_m_miner_solid_01.xml
@@ -7,6 +7,6 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_left </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_right </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_left combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile mining platformcollision symmetry symmetry_right combat</replace>
 </diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_fighter_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_fighter_01.xml
@@ -8,7 +8,7 @@
 	 </connection>
 </add>
 	
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right highpower </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left highpower </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left highpower combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_fighter_02.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_fighter_02.xml
@@ -8,8 +8,8 @@
 	 </connection>
 	</add>
 	
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision missile highpower </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision missile highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_heavyfighter_01.xml
@@ -8,10 +8,10 @@
 	 </connection>
 	</add>
 	
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 highpower </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision missile highpower </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_05']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision missile highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_05']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_heavyfighter_02.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_heavyfighter_02.xml
@@ -8,9 +8,9 @@
 	 </connection>
 	</add>
 	
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 highpower </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 highpower</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 highpower</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 highpower combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 highpower combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_miner_solid_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_miner_solid_01.xml
@@ -8,7 +8,7 @@
 	 </connection>
 	</add>
 
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_1 symmetry_right  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile mining symmetry symmetry_1 symmetry_left  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard mining missile symmetry symmetry_1 symmetry_right combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile mining symmetry symmetry_1 symmetry_left combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_scout_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_scout_01.xml
@@ -8,6 +8,6 @@
 	 </connection>
 	</add>
 	
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right highpower</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right highpower combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_trans_container_01.xml
+++ b/extensions/ego_dlc_split/assets/units/size_s/ship_spl_s_trans_container_01.xml
@@ -8,7 +8,7 @@
 	 </connection>
 	</add>
 
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_1 symmetry_right  </replace>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_1 symmetry_left  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_1 symmetry_right combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_1 symmetry_left combat</replace>
 	
 	</diff>

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/capital/weapon_atf_xl_battleship_01_mk1.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/capital/weapon_atf_xl_battleship_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<!-- <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace> -->
@@ -168,7 +168,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_weapon_01" tags="component weapon mandatory extralarge standard atf_battleship_01 ">
+			<connection name="con_weapon_01" tags="component weapon mandatory extralarge standard combat atf_battleship_01 combat">
 				<offset/>
 			</connection>
 			<connection name="Con_laser01" tags="laser ">

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/capital/weapon_ter_l_destroyer_01_mk1.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/capital/weapon_ter_l_destroyer_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<!-- <replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace> -->
@@ -276,7 +276,7 @@
 					</part>
 				</parts>
 			</connection>
-			<connection name="con_weapon_01" tags="component weapon large standard ter_destroyer_01 ">
+			<connection name="con_weapon_01" tags="component weapon large standard combat ter_destroyer_01 combat">
 				<offset/>
 			</connection>
 		</connections>

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/highpower/weapon_ter_m_gatling_01_mk2.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/highpower/weapon_ter_m_gatling_01_mk2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/highpower/weapon_ter_s_gatling_01_mk2.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/highpower/weapon_ter_s_gatling_01_mk2.xml
@@ -1,6 +1,6 @@
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon small standard ">
+	<connection name="WeaponCon_01" tags="component weapon small standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/standard/weapon_ter_m_laser_01_mk1.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/standard/weapon_ter_m_laser_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon medium standard ">
+	<connection name="WeaponCon_01" tags="component weapon medium standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_terran/assets/props/weaponsystems/standard/weapon_ter_s_laser_01_mk1.xml
+++ b/extensions/ego_dlc_terran/assets/props/weaponsystems/standard/weapon_ter_s_laser_01_mk1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <diff>
 	<replace sel="//components/component/connections/connection[@name='WeaponCon_01']">
-	<connection name="WeaponCon_01" tags="component weapon small standard ">
+	<connection name="WeaponCon_01" tags="component weapon small standard combat">
 					<offset/>
 	</connection>
 	</replace>

--- a/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_disc_01.xml
+++ b/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_disc_01.xml
@@ -406,25 +406,25 @@
 					<quaternion qx="-0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-195.6412" y="-1.525879E-04" z="338.6845"/>
 					<quaternion qx="0.1830127" qy="-0.6830127" qz="-0.6830127" qw="-0.1830127"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-338.7725" y="-1.525879E-04" z="195.4889"/>
 					<quaternion qx="0.3535534" qy="-0.6123724" qz="-0.6123725" qw="-0.3535534"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-195.4888" y="-1.525879E-04" z="-338.7724"/>
 					<quaternion qx="0.6830126" qy="-0.1830129" qz="-0.1830128" qw="-0.6830127"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-338.6845" y="-1.525879E-04" z="-195.6412"/>
 					<quaternion qx="0.6123723" qy="-0.3535535" qz="-0.3535534" qw="-0.6123725"/>
@@ -442,73 +442,73 @@
 					<quaternion qx="-0.7071069" qy="2.219724E-07" qz="0.7071066" qw="2.219725E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="266.5794" y="47.16416" z="267.58"/>
 					<quaternion qx="-0.2056156" qy="-0.7791921" qz="-0.4964002" qw="0.3227518"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-267.5803" y="47.16417" z="266.58"/>
 					<quaternion qx="0.2056156" qy="-0.7791919" qz="-0.4964002" qw="-0.3227522"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="267.5795" y="-47.1641" z="266.58"/>
 					<quaternion qx="-0.7791921" qy="-0.2056156" qz="0.3227518" qw="-0.4964003"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-266.5803" y="-47.16411" z="267.58"/>
 					<quaternion qx="-0.7791919" qy="0.2056157" qz="-0.3227523" qw="-0.4964002"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-331.2726" y="-1.525879E-04" z="208.4792"/>
 					<quaternion qx="0.3535534" qy="-0.6123724" qz="-0.6123725" qw="-0.3535534"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-346.2723" y="-1.525879E-04" z="182.4986"/>
 					<quaternion qx="0.3535538" qy="-0.6123722" qz="-0.6123723" qw="-0.3535536"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-208.6317" y="-1.525879E-04" z="331.1842"/>
 					<quaternion qx="0.1830129" qy="-0.6830127" qz="-0.6830127" qw="-0.1830129"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-182.6508" y="-1.525879E-04" z="346.1844"/>
 					<quaternion qx="0.1830129" qy="-0.6830127" qz="-0.6830127" qw="-0.1830129"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-346.1844" y="-1.525879E-04" z="-182.6508"/>
 					<quaternion qx="0.6123723" qy="-0.3535535" qz="-0.3535534" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-331.1842" y="-1.525879E-04" z="-208.6317"/>
 					<quaternion qx="0.6123723" qy="-0.3535535" qz="-0.3535534" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-208.479" y="-1.525879E-04" z="-331.2725"/>
 					<quaternion qx="0.6830127" qy="-0.1830125" qz="-0.1830124" qw="-0.6830128"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-182.4984" y="-1.525879E-04" z="-346.2722"/>
 					<quaternion qx="0.6830127" qy="-0.1830125" qz="-0.1830125" qw="-0.6830128"/>
@@ -526,97 +526,97 @@
 					<quaternion qx="-0.7071069" qy="5.338508E-08" qz="-0.7071066" qw="-5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="267.5794" y="47.16416" z="-266.5798"/>
 					<quaternion qx="0.4964003" qy="0.322752" qz="0.2056158" qw="-0.7791919"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-266.5804" y="47.16416" z="-267.5799"/>
 					<quaternion qx="0.4964001" qy="-0.3227518" qz="-0.2056156" qw="-0.7791921"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-267.5803" y="-47.16424" z="-266.5799"/>
 					<quaternion qx="-0.3227523" qy="0.4963999" qz="-0.7791921" qw="-0.2056156"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="266.5794" y="-47.16421" z="-267.5799"/>
 					<quaternion qx="0.3227516" qy="0.4964001" qz="-0.7791921" qw="0.2056162"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group09" tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group09" tags="medium shield hittable standard ">
 				<offset>
 					<position x="195.4887" y="-1.525879E-04" z="338.7724"/>
 					<quaternion qx="-0.1830128" qy="-0.6830127" qz="-0.6830127" qw="0.183013"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group09" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group09" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="182.4984" y="-1.525879E-04" z="346.2722"/>
 					<quaternion qx="-0.1830125" qy="-0.6830128" qz="-0.6830127" qw="0.1830125"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group09" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group09" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="208.479" y="-1.525879E-04" z="331.2725"/>
 					<quaternion qx="-0.1830125" qy="-0.6830128" qz="-0.6830127" qw="0.1830125"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group10" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_011" group="group10" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="346.1843" y="-1.525879E-04" z="182.6509"/>
 					<quaternion qx="-0.3535533" qy="-0.6123725" qz="-0.6123724" qw="0.3535534"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group10" tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group10" tags="medium shield hittable standard ">
 				<offset>
 					<position x="338.6844" y="-1.525879E-04" z="195.6412"/>
 					<quaternion qx="-0.3535533" qy="-0.6123725" qz="-0.6123724" qw="0.3535534"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group10" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_012" group="group10" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="331.1842" y="-1.525879E-04" z="208.6318"/>
 					<quaternion qx="-0.3535534" qy="-0.6123725" qz="-0.6123723" qw="0.3535535"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group11" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_013" group="group11" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="331.2726" y="-1.525879E-04" z="-208.4792"/>
 					<quaternion qx="0.6123725" qy="0.3535534" qz="0.3535534" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group11" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_014" group="group11" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="346.2723" y="-1.525879E-04" z="-182.4986"/>
 					<quaternion qx="0.6123722" qy="0.3535536" qz="0.3535537" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group11" tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group11" tags="medium shield hittable standard ">
 				<offset>
 					<position x="338.7725" y="-1.525879E-04" z="-195.4889"/>
 					<quaternion qx="0.6123725" qy="0.3535534" qz="0.3535534" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group12" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_015" group="group12" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="182.6509" y="-1.525879E-04" z="-346.1843"/>
 					<quaternion qx="0.6830127" qy="0.1830128" qz="0.1830128" qw="-0.6830127"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group12" tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group12" tags="medium shield hittable standard ">
 				<offset>
 					<position x="195.6412" y="-1.525879E-04" z="-338.6844"/>
 					<quaternion qx="0.6830128" qy="0.1830128" qz="0.1830128" qw="-0.6830126"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_016" group="group12" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_016" group="group12" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="208.6318" y="-1.525879E-04" z="-331.1842"/>
 					<quaternion qx="0.6830127" qy="0.1830128" qz="0.1830128" qw="-0.6830127"/>

--- a/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_disc_01.xml
+++ b/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_disc_01.xml
@@ -430,13 +430,13 @@
 					<quaternion qx="0.6123723" qy="-0.3535535" qz="-0.3535534" qw="-0.6123725"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05" tags="large shield standard">
 				<offset>
 					<position x="-4.882813E-04" y="73" z="314"/>
 					<quaternion qx="-0" qy="-0.7071066" qz="-0" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06" tags="large shield standard">
 				<offset>
 					<position x="-4.882813E-04" y="-73" z="314"/>
 					<quaternion qx="-0.7071069" qy="2.219724E-07" qz="0.7071066" qw="2.219725E-07"/>
@@ -514,13 +514,13 @@
 					<quaternion qx="0.6830127" qy="-0.1830125" qz="-0.1830125" qw="-0.6830128"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield standard">
 				<offset>
 					<position x="-4.882813E-04" y="73" z="-314"/>
 					<quaternion qx="-1.099213E-08" qy="0.7071066" qz="1.099213E-08" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield ">
+			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield standard">
 				<offset>
 					<position x="-4.882813E-04" y="-73" z="-314"/>
 					<quaternion qx="-0.7071069" qy="5.338508E-08" qz="-0.7071066" qw="-5.338508E-08"/>

--- a/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_tube_01.xml
+++ b/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_tube_01.xml
@@ -307,13 +307,13 @@
 					<quaternion qx="2.512148E-15" qy="-0.7071068" qz="6.181724E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_001" group="group05" tags="large shield ">
+			<connection name="con_shieldgen_large_001" group="group05" tags="large shield standard">
 				<offset>
 					<position x="0" y="40.00003" z="100.0004"/>
 					<quaternion qx="-1.685874E-07" qy="-0.7071066" qz="-1.685874E-07" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_002" group="group06" tags="large shield ">
+			<connection name="con_shieldgen_large_002" group="group06" tags="large shield standard">
 				<offset>
 					<position x="0" y="40.00003" z="-99.99957"/>
 					<quaternion qx="-0" qy="-0.7071066" qz="-0" qw="-0.7071069"/>
@@ -383,13 +383,13 @@
 					<position x="-50" y="45.00003" z="-344.0001"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield ">
+			<connection name="con_shieldgen_large_003" group="group07 " tags="large shield standard">
 				<offset>
 					<position x="0" y="-39.99997" z="100.0004"/>
 					<quaternion qx="0.7071067" qy="3.090862E-08" qz="-0.7071068" qw="-3.090862E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield ">
+			<connection name="con_shieldgen_large_004" group="group08  " tags="large shield standard">
 				<offset>
 					<position x="0" y="-39.99997" z="-99.99963"/>
 					<quaternion qx="0.7071066" qy="5.338509E-08" qz="-0.7071069" qw="5.338507E-08"/>

--- a/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_tube_01.xml
+++ b/extensions/ego_dlc_terran/assets/structures/defence/defence_ter_tube_01.xml
@@ -283,25 +283,25 @@
 					<quaternion qx="-0" qy="-1" qz="-0" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_001" group="group01 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="50" y="44.00003" z="323.9999"/>
 					<quaternion qx="2.980232E-08" qy="-0.7071068" qz="-1.490116E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_002" group="group02 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-50" y="45.00003" z="323.9999"/>
 					<quaternion qx="1.117587E-08" qy="-0.7071068" qz="1.117587E-08" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_004" group="group04 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-50" y="45.00003" z="-324.0001"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="6.181724E-08" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable ">
+			<connection name="con_shieldgen_003" group="group03 " tags="medium shield hittable standard ">
 				<offset>
 					<position x="50" y="44.00003" z="-324.0001"/>
 					<quaternion qx="2.512148E-15" qy="-0.7071068" qz="6.181724E-08" qw="-0.7071067"/>
@@ -319,66 +319,66 @@
 					<quaternion qx="-0" qy="-0.7071066" qz="-0" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_001" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="50" y="40.00003" z="200.0004"/>
 					<quaternion qx="4.889444E-08" qy="-0.7071068" qz="-4.889444E-08" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_002" group="group05" tags="turret large standard missile combat">
 				<offset>
 					<position x="-50" y="40.00003" z="200.0004"/>
 					<quaternion qx="-2.619345E-09" qy="0.7071068" qz="2.619345E-09" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_003" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="50" y="40.00003" z="-199.9996"/>
 					<quaternion qx="-0" qy="-0.7071068" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_004" group="group06 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-50" y="40.00003" z="-199.9996"/>
 					<quaternion qx="-0" qy="0.7071074" qz="-0" qw="-0.7071061"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_001" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="45.00003" z="343.9999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_002" group="group02 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="45.00003" z="303.9999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_003" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="44.00003" z="303.9999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_004" group="group01 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="44.00003" z="343.9999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_005" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="44.00003" z="-304"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_006" group="group03 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="44.00003" z="-344.0001"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group04  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="45.00003" z="-304.0001"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group04 " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="45.00003" z="-344.0001"/>
 				</offset>
@@ -395,97 +395,97 @@
 					<quaternion qx="0.7071066" qy="5.338509E-08" qz="-0.7071069" qw="5.338507E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_013" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="50" y="-39.99994" z="200.0004"/>
 					<quaternion qx="-0.7071065" qy="-1.376788E-07" qz="-0.707107" qw="1.99496E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_014" group="group07 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-50" y="-39.99994" z="200.0004"/>
 					<quaternion qx="0.7071067" qy="-3.680834E-07" qz="-0.7071068" qw="3.090863E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_015" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="50" y="-40" z="-199.9996"/>
 					<quaternion qx="-0.7071068" qy="-1.376788E-07" qz="-0.7071068" qw="1.99496E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile ">
+			<connection name="con_turret_laser_l_016" group="group08 " tags="turret large standard missile combat">
 				<offset>
 					<position x="-50" y="-40" z="-199.9996"/>
 					<quaternion qx="-0.7071069" qy="2.837897E-07" qz="0.7071066" qw="5.338513E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_005" group="group09" tags="medium shield hittable ">
+			<connection name="con_shieldgen_005" group="group09" tags="medium shield hittable standard ">
 				<offset>
 					<position x="50" y="-44.99997" z="-324.0001"/>
 					<quaternion qx="0.7071068" qy="-2.837897E-07" qz="-0.7071068" qw="-5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group09" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group09" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="-44.99997" z="-304.0001"/>
 					<quaternion qx="2.384186E-07" qy="2.384186E-07" qz="-1" qw="-4.371133E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_010" group="group09" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_010" group="group09" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="-44.99997" z="-344.0001"/>
 					<quaternion qx="2.384186E-07" qy="2.384186E-07" qz="-1" qw="4.371145E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_011" group="group10" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_011" group="group10" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="-43.99997" z="-344.0001"/>
 					<quaternion qx="2.384186E-07" qy="2.384186E-07" qz="-1" qw="4.371145E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_006" group="group10" tags="medium shield hittable ">
+			<connection name="con_shieldgen_006" group="group10" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-50" y="-43.99997" z="-324.0001"/>
 					<quaternion qx="-0.7071069" qy="1.99496E-07" qz="0.7071066" qw="1.376788E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_012" group="group10" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_012" group="group10" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="-43.99997" z="-304.0001"/>
 					<quaternion qx="2.384186E-07" qy="2.384186E-07" qz="-1" qw="-4.371133E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_013" group="group11" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_013" group="group11" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="-44.99997" z="343.9999"/>
 					<quaternion qx="7.549789E-08" qy="2.8213E-07" qz="-1" qw="4.623147E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_014" group="group11" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_014" group="group11" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="50" y="-44.99997" z="303.9999"/>
 					<quaternion qx="2.8213E-07" qy="2.8213E-07" qz="-1" qw="5.224145E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_007" group="group11" tags="medium shield hittable ">
+			<connection name="con_shieldgen_007" group="group11" tags="medium shield hittable standard ">
 				<offset>
 					<position x="50" y="-44.99997" z="323.9999"/>
 					<quaternion qx="-0.7071068" qy="5.338508E-08" qz="0.7071067" qw="5.338508E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_015" group="group12" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_015" group="group12" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="-43.99997" z="303.9999"/>
 					<quaternion qx="1.629207E-07" qy="2.8213E-07" qz="-1" qw="8.288777E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_008" group="group12" tags="medium shield hittable ">
+			<connection name="con_shieldgen_008" group="group12" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-50" y="-43.99997" z="323.9999"/>
 					<quaternion qx="-0.7071068" qy="-1.152023E-07" qz="0.7071067" qw="-1.152023E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_016" group="group12" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_016" group="group12" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-50" y="-43.99997" z="343.9999"/>
 					<quaternion qx="1.629207E-07" qy="2.8213E-07" qz="-1" qw="8.288777E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
@@ -9,10 +9,10 @@
 	 </connection>
 	</add>
 
-	<replace  sel="/components/component/connections/connection[@name='con_turret_l_01']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_l_04']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_l_05']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_l_07']/@tags"> turret large standard highpower terronly</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_l_01']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_l_04']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_l_05']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_l_07']/@tags">turret large standard highpower terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -356,12 +356,12 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="8.899172" y="24.02254" z="-259.9495"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_back_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_back_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="37.483" z="-107.6271"/>
 				</offset>
@@ -377,29 +377,29 @@
 					<position x="0" y="24.47267" z="84.5224"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_03" group="group_mid_up_left_2" tags="turret large standard ">
+			<connection name="con_turret_l_03" group="group_mid_up_left_2" tags="turret large standard combat">
 				<offset>
 					<position x="-80.64606" y="20.48551" z="103.0842"/>
 					<quaternion qx="-4.125072E-05" qy="3.691758E-04" qz="-9.547026E-02" qw="-0.9954323"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right">
+			<connection name="con_weapon_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="51.001" y="-23.189" z="417.903"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right">
+			<connection name="con_weapon_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="-51.00146" y="-23.18891" z="417.9026"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_02" group="group_mid_right_up_2" tags="turret large standard ">
+			<connection name="con_turret_l_02" group="group_mid_right_up_2" tags="turret large standard combat">
 				<offset>
 					<position x="80.54404" y="20.38029" z="104.5011"/>
 					<quaternion qx="1.521608E-05" qy="3.653049E-04" qz="9.546719E-02" qw="-0.9954325"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-4.400881" y="24.02254" z="-259.9495"/>
 				</offset>
@@ -434,177 +434,177 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="36.0063" z="-126.4688"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-91.04559" z="-146.4398"/>
 					<quaternion qx="-7.549804E-08" qy="-9.417494E-07" qz="-1" qw="-1.509957E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_back_up_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_back_up_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="37.37751" z="-165.2781"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_back_down_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_back_down_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-91.04266" z="-126.4397"/>
 					<quaternion qx="1.192471E-08" qy="9.655992E-07" qz="-1" qw="1.748456E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_back_down_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_back_down_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-91.04526" z="-186.4397"/>
 					<quaternion qx="1.192496E-08" qy="-4.649123E-07" qz="-1" qw="1.748456E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_mid_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_mid_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-114.2077" y="6.742635" z="84.70397"/>
 					<quaternion qx="-1.534099E-05" qy="-8.154961E-07" qz="-0.3272518" qw="-0.9449372"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_mid_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_mid_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-113.6961" y="7.143741" z="126.3333"/>
 					<quaternion qx="-1.410634E-05" qy="-6.852068E-07" qz="-0.327247" qw="-0.9449388"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_mid_right_up_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_mid_right_up_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="113.2661" y="7.407436" z="84.51218"/>
 					<quaternion qx="-1.638855E-05" qy="-8.449844E-06" qz="0.3302343" qw="-0.943899"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_mid_right_up_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_mid_right_up_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="113.6273" y="7.094059" z="126.1414"/>
 					<quaternion qx="-1.653552E-05" qy="-8.029767E-06" qz="0.3302343" qw="-0.943899"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon large standard ter_destroyer_01 ">
+			<connection name="con_weapon_03" tags="weapon large standard ter_destroyer_01 combat">
 				<offset>
 					<position x="0" y="-6.311953" z="452.0676"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_04" group="group_mid_up_left_1" tags="turret large standard ">
+			<connection name="con_turret_l_04" group="group_mid_up_left_1" tags="turret large standard combat">
 				<offset>
 					<position x="-106.1111" y="28.0569" z="-56.05561"/>
 					<quaternion qx="-3.742612E-04" qy="-2.487899E-05" qz="-6.003058E-02" qw="-0.9981965"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_mid_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_mid_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-63.21869" y="32.3074" z="-40.41126"/>
 					<quaternion qx="-1.667738E-05" qy="5.0505E-06" qz="-4.379562E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_mid_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_mid_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-63.21869" y="32.3074" z="-70.53333"/>
 					<quaternion qx="-1.810789E-05" qy="5.408131E-06" qz="7.539997E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_mid_right_up_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_mid_right_up_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="63.15511" y="32.3074" z="-70.53333"/>
 					<quaternion qx="-2.33531E-05" qy="-1.712242E-05" qz="7.589776E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_mid_right_up_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_mid_right_up_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="63.15511" y="32.3074" z="-40.41126"/>
 					<quaternion qx="-2.33531E-05" qy="-1.667737E-05" qz="7.588737E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_05" group="group_mid_right_up_1" tags="turret large standard ">
+			<connection name="con_turret_l_05" group="group_mid_right_up_1" tags="turret large standard combat">
 				<offset>
 					<position x="105.9283" y="28.30629" z="-55.89872"/>
 					<quaternion qx="2.853868E-05" qy="3.681389E-04" qz="6.001975E-02" qw="-0.9981971"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_06" group="group_mid_right_down_2" tags="turret large standard ">
+			<connection name="con_turret_l_06" group="group_mid_right_down_2" tags="turret large standard combat">
 				<offset>
 					<position x="77.21722" y="-33.8933" z="103.4647"/>
 					<quaternion qx="3.65518E-04" qy="1.595622E-05" qz="-0.9956027" qw="9.367549E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_mid_right_down_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_mid_right_down_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="113.8222" y="-20.20825" z="85.2354"/>
 					<quaternion qx="-8.430331E-06" qy="-1.637173E-05" qz="-0.943666" qw="0.3308993"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_mid_right_down_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_mid_right_down_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="113.4871" y="-20.46203" z="126.8647"/>
 					<quaternion qx="-8.010354E-06" qy="-1.651899E-05" qz="-0.9436661" qw="0.3308991"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_mid_right_down_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_mid_right_down_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="61.45347" y="-45.50547" z="-69.53212"/>
 					<quaternion qx="-1" qy="3.725292E-08" qz="-5.960463E-08" qw="-1.442436E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_mid_right_down_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_mid_right_down_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="61.45347" y="-45.50547" z="-41.48157"/>
 					<quaternion qx="-1" qy="1.261018E-13" qz="-8.742278E-08" qw="-1.442436E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_07" group="group_mid_right_down_1" tags="turret large standard ">
+			<connection name="con_turret_l_07" group="group_mid_right_down_1" tags="turret large standard combat">
 				<offset>
 					<position x="106.1499" y="-41.65363" z="-56.42952"/>
 					<quaternion qx="-1.077645E-03" qy="1.405142E-05" qz="-0.9981966" qw="6.001985E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_08" group="group_mid_down_left_2" tags="turret large standard ">
+			<connection name="con_turret_l_08" group="group_mid_down_left_2" tags="turret large standard combat">
 				<offset>
 					<position x="-77.68581" y="-34.06248" z="104.0237"/>
 					<quaternion qx="3.692223E-04" qy="-4.124858E-05" qz="-0.9954327" qw="-9.546439E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_17" group="group_mid_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_17" group="group_mid_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-114.009" y="-20.08138" z="126.5132"/>
 					<quaternion qx="-6.399542E-07" qy="-1.402728E-05" qz="-0.9436679" qw="-0.3308941"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_18" group="group_mid_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_18" group="group_mid_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-113.5053" y="-20.4857" z="84.88382"/>
 					<quaternion qx="-7.758198E-07" qy="-1.525887E-05" qz="-0.9436679" qw="-0.3308941"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_19" group="group_mid_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_19" group="group_mid_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-61.453" y="-45.505" z="-69.532"/>
 					<quaternion qx="-1" qy="8.74229E-08" qz="-8.940684E-08" qw="-1.442436E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_20" group="group_mid_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_20" group="group_mid_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-61.453" y="-45.505" z="-41.482"/>
 					<quaternion qx="-1" qy="8.74229E-08" qz="-8.742265E-08" qw="-1.442436E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_01" group="group_mid_down_left_1" tags="turret large standard ">
+			<connection name="con_turret_l_01" group="group_mid_down_left_1" tags="turret large standard combat">
 				<offset>
 					<position x="-105.602" y="-41.78577" z="-56.27925"/>
 					<quaternion qx="4.009107E-03" qy="-2.348644E-04" qz="-0.9981892" qw="-0.0600183"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_21" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_21" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="36.0063" z="-144.2391"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_22" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_22" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-90.96894" z="-165.9211"/>
 					<quaternion qx="-7.549804E-08" qy="-9.417494E-07" qz="-1" qw="-1.509957E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
@@ -334,7 +334,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="0" y="-4.097641" z="-317.1591"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_atf_l_destroyer_01.xml
@@ -339,7 +339,7 @@
 					<position x="0" y="-4.097641" z="-317.1591"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="71.75278" y="-6.672507" z="-204.9395"/>
 					<quaternion qx="-1.067702E-07" qy="1.067702E-07" qz="0.7071069" qw="-0.7071066"/>
@@ -366,7 +366,7 @@
 					<position x="0" y="37.483" z="-107.6271"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_02" tags="large shield">
+			<connection name="con_shieldgen_l_02" tags="large shield standard">
 				<offset>
 					<position x="-72.03298" y="-6.672507" z="-204.9395"/>
 					<quaternion qx="-1.109862E-07" qy="2.346207E-07" qz="-0.7071068" qw="-0.7071068"/>
@@ -404,7 +404,7 @@
 					<position x="-4.400881" y="24.02254" z="-259.9495"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_03" tags="large shield ">
+			<connection name="con_shieldgen_l_03" tags="large shield standard">
 				<offset>
 					<position x="0" y="-52.63561" z="-48.38436"/>
 					<quaternion qx="7.549779E-08" qy="-6.715443E-07" qz="-1" qw="-1.509958E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
@@ -254,7 +254,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_01" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="-26.78383" y="-0.1161746" z="-365.9877"/>
 				</offset>
@@ -424,7 +424,7 @@
 					<quaternion qx="-1.509958E-07" qy="8.026785E-07" qz="-1" qw="-1.1925E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large ">
+			<connection name="con_engine_02" group="group_back_mid_mid" tags="engine large standard">
 				<offset>
 					<position x="26.7838" y="-0.1161746" z="-365.9877"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
@@ -271,7 +271,7 @@
 					<quaternion qx="-1" qy="8.742278E-08" qz="8.441536E-14" qw="-9.655992E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="0" y="16.69576" z="-10.11232"/>
 				</offset>
@@ -309,7 +309,7 @@
 					<position x="-37.39547" y="19.44372" z="-37.92731"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_02" tags="large shield">
+			<connection name="con_shieldgen_l_02" tags="large shield standard">
 				<offset>
 					<position x="0" y="-18.46622" z="-80.27146"/>
 					<quaternion qx="-1" qy="-1.509958E-07" qz="-1.146008E-13" qw="-7.589671E-07"/>
@@ -377,7 +377,7 @@
 					<quaternion qx="7.964742E-08" qy="1.745259E-02" qz="-0.9998477" qw="-2.370646E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_03" tags="large shield ">
+			<connection name="con_shieldgen_l_03" tags="large shield standard">
 				<offset>
 					<position x="-4.813129E-05" y="16.69576" z="-79.36109"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_destroyer_01.xml
@@ -9,7 +9,7 @@
 	 </connection>
 	</add>
 
-	<replace  sel="/components/component/connections/connection[@name='con_turret_l_01']/@tags"> turret large standard highpower terronly</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_l_01']/@tags">turret large standard highpower terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -259,13 +259,13 @@
 					<position x="-26.78383" y="-0.1161746" z="-365.9877"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="29.48705" z="-286.295"/>
 					<quaternion qx="-6.400351E-05" qy="-0.9996543" qz="2.617639E-02" qw="-2.465802E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_down_mid_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_down_mid_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-39.26508" y="-19.43643" z="-59.82103"/>
 					<quaternion qx="-1" qy="8.742278E-08" qz="8.441536E-14" qw="-9.655992E-07"/>
@@ -287,24 +287,24 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-26.7516" y="23.9363" z="-349.1939"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_back_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_10" group="group_back_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="28.8004" z="-306.0385"/>
 					<quaternion qx="-6.400633E-05" qy="-0.9996543" qz="2.617655E-02" qw="-2.465889E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_09" group="group_down_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_09" group="group_down_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.3955" y="-19.45122" z="-82.16562"/>
 					<quaternion qx="-1.509958E-07" qy="8.026785E-07" qz="-1" qw="-1.1925E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_mid_up_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_mid_up_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.39547" y="19.44372" z="-37.92731"/>
 				</offset>
@@ -320,58 +320,58 @@
 					<position x="0" y="16.11646" z="50.37207"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_03" group="group_mid_up_left_2" tags="turret large standard ">
+			<connection name="con_turret_l_03" group="group_mid_up_left_2" tags="turret large standard combat">
 				<offset>
 					<position x="-82.839" y="11.98095" z="-59.65193"/>
 					<quaternion qx="2.315322E-10" qy="2.262051E-09" qz="-0.101823" qw="-0.9948025"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right">
+			<connection name="con_weapon_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="107.474" y="0" z="31.03641"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right">
+			<connection name="con_weapon_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="-107.4742" y="0" z="31.03641"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_02" group="group_mid_right_up_2" tags="turret large standard ">
+			<connection name="con_turret_l_02" group="group_mid_right_up_2" tags="turret large standard combat">
 				<offset>
 					<position x="82.839" y="11.98095" z="-59.65193"/>
 					<quaternion qx="-2.47549E-10" qy="2.260355E-09" qz="0.1088669" qw="-0.9940563"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l_01" group="group_front_down_mid" tags="turret large standard ">
+			<connection name="con_turret_l_01" group="group_front_down_mid" tags="turret large standard combat">
 				<offset>
 					<position x="0" y="-18.30663" z="32.89212"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_down_mid_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_down_mid_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.39547" y="-19.45122" z="-82.16562"/>
 					<quaternion qx="-2.384186E-07" qy="8.026785E-07" qz="-1" qw="-1.192507E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_down_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_down_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="39.2651" y="-19.43643" z="-59.82103"/>
 					<quaternion qx="-1" qy="-1.509956E-07" qz="-1.50996E-07" qw="-9.655992E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="26.77157" y="23.93631" z="-349.1939"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_back_down_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_back_down_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-28.95115" z="-306.0238"/>
 					<quaternion qx="1.220346E-07" qy="1.745296E-02" qz="-0.9998477" qw="-1.608153E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-29.61625" z="-286.3378"/>
 					<quaternion qx="7.964742E-08" qy="1.745259E-02" qz="-0.9998477" qw="-2.370646E-07"/>
@@ -406,19 +406,19 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="6.47297" y="-17.23223" z="-12.26024"/>
 					<quaternion qx="-1" qy="-8.742303E-08" qz="4.768371E-07" qw="-5.205485E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_down_mid_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_down_mid_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.39547" y="-19.44372" z="-37.51246"/>
 					<quaternion qx="3.258414E-07" qy="8.026785E-07" qz="-1" qw="-1.192462E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_down_mid_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_down_mid_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.3955" y="-19.44372" z="-37.51246"/>
 					<quaternion qx="-1.509958E-07" qy="8.026785E-07" qz="-1" qw="-1.1925E-08"/>
@@ -429,68 +429,68 @@
 					<position x="26.7838" y="-0.1161746" z="-365.9877"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_front_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_front_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-6.472968" y="-17.23223" z="-12.26024"/>
 					<quaternion qx="-1" qy="-8.742303E-08" qz="4.768371E-07" qw="-5.205485E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_mid_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_mid_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-38.33975" y="19.39613" z="-59.80163"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_mid_right_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_mid_right_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="38.3398" y="19.39613" z="-59.80163"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_mid_up_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_mid_up_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.39547" y="19.45122" z="-82.65176"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_right_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_right_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.3955" y="19.44372" z="-37.8245"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_mid_right_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_mid_right_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.3955" y="19.45122" z="-82.6141"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="26.75159" y="-23.9363" z="-349.1939"/>
 					<quaternion qx="-1.424298E-14" qy="3.258414E-07" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_back_mid_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_back_mid_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-26.7516" y="-23.9363" z="-349.1939"/>
 					<quaternion qx="-1.424298E-14" qy="3.258414E-07" qz="-1" qw="4.371139E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_mid_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_mid_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-107.4742" y="6.976633" z="-9.955959"/>
 					<quaternion qx="-6.350087E-07" qy="0.7071068" qz="-6.96826E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_mid_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_mid_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-107.4742" y="6.976633" z="12.62884"/>
 					<quaternion qx="-1.309358E-06" qy="0.7071068" qz="-2.247645E-08" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_mid_right_up_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_mid_right_up_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="107.3896" y="6.976633" z="-9.955961"/>
 					<quaternion qx="-6.96826E-07" qy="-0.7071068" qz="6.350088E-07" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_mid_right_up_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_mid_right_up_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="107.3896" y="6.976633" z="12.62884"/>
 					<quaternion qx="-2.247669E-08" qy="-0.7071066" qz="1.309358E-06" qw="-0.7071069"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
@@ -386,7 +386,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large standard">
 				<offset>
 					<position x="0" y="-10.3126" z="-268.6246"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
@@ -397,55 +397,55 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="3.814697E-06" y="18.53489" z="-255.043"/>
 					<quaternion qx="-1.192488E-08" qy="-1" qz="-4.371139E-08" qw="-5.212531E-16"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.57464" y="15.28368" z="39.6659"/>
 					<quaternion qx="-7.559556E-03" qy="0.0369222" qz="4.393085E-02" qw="-0.9983234"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-34.48405" y="14.81" z="89.637"/>
 					<quaternion qx="-7.906446E-03" qy="-3.546138E-02" qz="-4.464936E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-32.50572" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166875E-02" qy="-1.389165E-02" qz="-0.8546926" qw="-0.5179814"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-33.00225" z="-255.423"/>
 					<quaternion qx="1.139987E-14" qy="-1.509958E-07" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.430511E-05" y="-24.94496" z="-56.08788"/>
 					<quaternion qx="1.605792E-07" qy="2.614582E-02" qz="-0.9996581" qw="9.165257E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-32.69301" y="1.339282" z="206.0865"/>
 					<quaternion qx="-3.001889E-02" qy="-8.296681E-03" qz="-0.8737218" qw="-0.4854279"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-9.059906E-06" y="-27.85221" z="-36.66078"/>
 					<quaternion qx="3.264641E-07" qy="3.264641E-07" qz="-0.9999982" qw="-1.913082E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="16.16245" z="-273.7814"/>
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
@@ -468,19 +468,19 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="27.855" y="14.914" z="63.727"/>
 					<quaternion qx="8.570193E-06" qy="-1.588322E-03" qz="5.340632E-03" qw="-0.9999845"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-27.85509" y="14.91373" z="63.72742"/>
 					<quaternion qx="-8.410671E-06" qy="-1.584657E-03" qz="-5.340394E-03" qw="-0.9999844"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.575" y="15.284" z="39.66653"/>
 					<quaternion qx="-7.562648E-03" qy="-3.692228E-02" qz="-4.392866E-02" qw="-0.9983235"/>
@@ -491,19 +491,19 @@
 					<position x="0" y="13.24893" z="89.36286"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="34.48043" y="14.81034" z="89.63728"/>
 					<quaternion qx="-7.905921E-03" qy="3.545943E-02" qz="4.465049E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="32.693" y="1.339282" z="206.0865"/>
 					<quaternion qx="3.002086E-02" qy="-8.297981E-03" qz="-0.8737201" qw="0.4854307"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="32.506" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166441E-02" qy="0.0138908" qz="0.8546929" qw="-0.5179813"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_liquid_01.xml
@@ -451,7 +451,7 @@
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="5.193055E-06" y="-26.21284" z="-181.0515"/>
 					<quaternion qx="-1" qy="-4.371136E-08" qz="-7.549792E-08" qw="-3.258414E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
@@ -445,7 +445,7 @@
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="5.193055E-06" y="-26.21284" z="-181.0515"/>
 					<quaternion qx="-1" qy="-4.371136E-08" qz="-7.549792E-08" qw="-3.258414E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
@@ -380,7 +380,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large ">
+			<connection name="con_engine_01" group="group_back_down_mid " tags="engine large standard">
 				<offset>
 					<position x="0" y="-10.3126" z="-268.6246"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_miner_solid_01.xml
@@ -391,55 +391,55 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_back_up_mid " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="3.814697E-06" y="18.53489" z="-255.043"/>
 					<quaternion qx="-1.192488E-08" qy="-1" qz="-4.371139E-08" qw="-5.212531E-16"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="37.57464" y="15.28368" z="39.6659"/>
 					<quaternion qx="-7.559556E-03" qy="0.0369222" qz="4.393085E-02" qw="-0.9983234"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-34.48405" y="14.81" z="89.637"/>
 					<quaternion qx="-7.906446E-03" qy="-3.546138E-02" qz="-4.464936E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-32.50572" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166875E-02" qy="-1.389165E-02" qz="-0.8546926" qw="-0.5179814"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-33.00225" z="-255.423"/>
 					<quaternion qx="1.139987E-14" qy="-1.509958E-07" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_mid_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.430511E-05" y="-24.94496" z="-56.08788"/>
 					<quaternion qx="1.605792E-07" qy="2.614582E-02" qz="-0.9996581" qw="9.165257E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-32.69301" y="1.339282" z="206.0865"/>
 					<quaternion qx="-3.001889E-02" qy="-8.296681E-03" qz="-0.8737218" qw="-0.4854279"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_mid_down " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-9.059906E-06" y="-27.85221" z="-36.66078"/>
 					<quaternion qx="3.264641E-07" qy="3.264641E-07" qz="-0.9999982" qw="-1.913082E-03"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_up_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="16.16245" z="-273.7814"/>
 					<quaternion qx="1.230135E-02" qy="-0.9999214" qz="-1.897001E-03" qw="1.518123E-03"/>
@@ -462,24 +462,24 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_down_mid " tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_down_mid " tags="medium shield hittable standard ">
 				<offset>
 					<position x="9.536743E-07" y="27.69783" z="-129.8475"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_mid_mid_right " tags="medium shield hittable standard ">
 				<offset>
 					<position x="27.855" y="14.914" z="63.727"/>
 					<quaternion qx="8.570193E-06" qy="-1.588322E-03" qz="5.340632E-03" qw="-0.9999845"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_mid_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="-27.85509" y="14.91373" z="63.72742"/>
 					<quaternion qx="-8.410671E-06" qy="-1.584657E-03" qz="-5.340394E-03" qw="-0.9999844"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_007" group="group_mid_mid_left  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-37.575" y="15.284" z="39.66653"/>
 					<quaternion qx="-7.562648E-03" qy="-3.692228E-02" qz="-4.392866E-02" qw="-0.9983235"/>
@@ -490,19 +490,19 @@
 					<position x="0" y="13.24893" z="89.36286"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_008" group="group_mid_mid_right  " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="34.48043" y="14.81034" z="89.63728"/>
 					<quaternion qx="-7.905921E-03" qy="3.545943E-02" qz="4.465049E-02" qw="-0.9983419"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable ">
+			<connection name="con_turret_009" group="group_front_mid_left " tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="32.693" y="1.339282" z="206.0865"/>
 					<quaternion qx="3.002086E-02" qy="-8.297981E-03" qz="-0.8737201" qw="0.4854307"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable ">
+			<connection name="con_shieldgen_011" group="group_front_mid_left " tags="medium shield hittable standard ">
 				<offset>
 					<position x="32.506" y="6.272362" z="232.0131"/>
 					<quaternion qx="-3.166441E-02" qy="0.0138908" qz="0.8546929" qw="-0.5179813"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
@@ -890,36 +890,36 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-46.46014" y="4.435039E-02" z="-212.9972"/>
 					<quaternion qx="0.700321" qy="-0.7010677" qz="9.772611E-02" qw="-0.0922176"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.3181" y="8.475482" z="270.4764"/>
 					<quaternion qx="-1.197758E-02" qy="5.984072E-02" qz="0.1958992" qw="-0.9787232"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_07" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_07" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="23.11304" z="-235.6831"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_02" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_02" tags="medium shield hittable standard ">
 				<offset>
 					<position x="68.76758" y="-0.1993322" z="26.72417"/>
 					<quaternion qx="1.120576E-03" qy="-1.120584E-03" qz="0.7071059" qw="-0.7071059"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_01" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_01" tags="medium shield hittable standard ">
 				<offset>
 					<position x="44.40457" y="4.515266E-02" z="271.3504"/>
 					<quaternion qx="-4.657522E-02" qy="4.657344E-02" qz="0.7055712" qw="-0.7055714"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-61.73357" y="4.823685E-03" z="-156.0535"/>
 					<quaternion qx="0.7003204" qy="-0.7010671" qz="9.773084E-02" qw="-9.222233E-02"/>
@@ -941,49 +941,49 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_05" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_05" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-52.05298" y="2.151442E-02" z="-182.8535"/>
 					<quaternion qx="0.7006997" qy="-0.7006998" qz="9.497302E-02" qw="-9.497307E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="65.04158" y="8.441695" z="26.31445"/>
 					<quaternion qx="2.181336E-09" qy="4.009424E-08" qz="0.2164396" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="65.1748" y="-8.563053" z="26.22304"/>
 					<quaternion qx="1.564778E-07" qy="-2.362024E-08" qz="-0.976296" qw="0.2164394"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.3139" y="-8.49942" z="270.5066"/>
 					<quaternion qx="7.271414E-02" qy="-2.056433E-02" qz="-0.9697201" qw="0.2322343"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_03" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_03" tags="medium shield hittable standard ">
 				<offset>
 					<position x="16.18387" y="-10.13375" z="265.2139"/>
 					<quaternion qx="0.7071067" qy="-8.96322E-07" qz="-0.7071068" qw="9.131865E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_06" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_06" tags="medium shield hittable standard ">
 				<offset>
 					<position x="52.18273" y="-3.594637E-02" z="-182.9004"/>
 					<quaternion qx="-0.7006998" qy="-0.7006997" qz="9.497276E-02" qw="9.497276E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="61.62465" y="3.986961E-02" z="-156.1214"/>
 					<quaternion qx="-0.7010674" qy="-0.700321" qz="9.221908E-02" qw="9.772717E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="46.97872" y="4.822552E-03" z="-212.9554"/>
 					<quaternion qx="-0.7010668" qy="-0.7003201" qz="9.222487E-02" qw="9.773294E-02"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
@@ -879,7 +879,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_07" tags="engine large ">
+			<connection name="con_engine_01" group="group_07" tags="engine large standard">
 				<offset>
 					<position x="0.7941079" y="0" z="-248.2205"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_research_01.xml
@@ -925,7 +925,7 @@
 					<quaternion qx="0.7003204" qy="-0.7010671" qz="9.773084E-02" qw="-9.222233E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="0.8594155" y="10.03693" z="-161.0245"/>
 				</offset>
@@ -989,7 +989,7 @@
 					<quaternion qx="-0.7010668" qy="-0.7003201" qz="9.222487E-02" qw="9.773294E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_02" tags="large shield ">
+			<connection name="con_shieldgen_l_02" tags="large shield standard">
 				<offset>
 					<position x="0" y="-9.955818" z="-161.0245"/>
 					<quaternion qx="7.549801E-08" qy="7.589671E-07" qz="-1" qw="-1.509957E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
@@ -873,36 +873,36 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-46.46014" y="4.435039E-02" z="-212.9972"/>
 					<quaternion qx="0.700321" qy="-0.7010677" qz="9.772611E-02" qw="-0.0922176"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_01" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_01" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.3181" y="8.475482" z="270.4764"/>
 					<quaternion qx="-1.197758E-02" qy="5.984072E-02" qz="0.1958992" qw="-0.9787232"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_07" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_07" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="23.11304" z="-235.6831"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_02" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_02" tags="medium shield hittable standard ">
 				<offset>
 					<position x="68.76758" y="-0.1993322" z="26.72417"/>
 					<quaternion qx="1.120576E-03" qy="-1.120584E-03" qz="0.7071059" qw="-0.7071059"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_01" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_01" tags="medium shield hittable standard ">
 				<offset>
 					<position x="44.40457" y="4.515266E-02" z="271.3504"/>
 					<quaternion qx="-4.657522E-02" qy="4.657344E-02" qz="0.7055712" qw="-0.7055714"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_05" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_05" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-61.73357" y="4.823685E-03" z="-156.0535"/>
 					<quaternion qx="0.7003204" qy="-0.7010671" qz="9.773084E-02" qw="-9.222233E-02"/>
@@ -919,49 +919,49 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_05" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_05" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-52.05298" y="2.151442E-02" z="-182.8535"/>
 					<quaternion qx="0.7006997" qy="-0.7006998" qz="9.497302E-02" qw="-9.497307E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="65.04158" y="8.441695" z="26.31445"/>
 					<quaternion qx="2.181336E-09" qy="4.009424E-08" qz="0.2164396" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_02" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_02" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="65.1748" y="-8.563053" z="26.22304"/>
 					<quaternion qx="1.564778E-07" qy="-2.362024E-08" qz="-0.976296" qw="0.2164394"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_03" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_03" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.3139" y="-8.49942" z="270.5066"/>
 					<quaternion qx="7.271414E-02" qy="-2.056433E-02" qz="-0.9697201" qw="0.2322343"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_03" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_03" tags="medium shield hittable standard ">
 				<offset>
 					<position x="16.18387" y="-10.13375" z="265.2139"/>
 					<quaternion qx="0.7071067" qy="-8.96322E-07" qz="-0.7071068" qw="9.131865E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_06" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_06" tags="medium shield hittable standard ">
 				<offset>
 					<position x="52.18273" y="-3.594637E-02" z="-182.9004"/>
 					<quaternion qx="-0.7006998" qy="-0.7006997" qz="9.497276E-02" qw="9.497276E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="61.62465" y="3.986961E-02" z="-156.1214"/>
 					<quaternion qx="-0.7010674" qy="-0.700321" qz="9.221908E-02" qw="9.772717E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_06" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_06" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="46.97872" y="4.822552E-03" z="-212.9554"/>
 					<quaternion qx="-0.7010668" qy="-0.7003201" qz="9.222487E-02" qw="9.773294E-02"/>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
@@ -862,7 +862,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="-0.5" qw="0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_07" tags="engine large ">
+			<connection name="con_engine_01" group="group_07" tags="engine large standard">
 				<offset>
 					<position x="0.7941079" y="0" z="-248.2205"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_l/ship_ter_l_trans_container_01.xml
@@ -908,7 +908,7 @@
 					<quaternion qx="0.7003204" qy="-0.7010671" qz="9.773084E-02" qw="-9.222233E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_01" tags="large shield ">
+			<connection name="con_shieldgen_l_01" tags="large shield standard">
 				<offset>
 					<position x="0.8594155" y="10.03693" z="-161.0245"/>
 				</offset>
@@ -967,7 +967,7 @@
 					<quaternion qx="-0.7010668" qy="-0.7003201" qz="9.222487E-02" qw="9.773294E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_l_02" tags="large shield ">
+			<connection name="con_shieldgen_l_02" tags="large shield standard">
 				<offset>
 					<position x="0" y="-9.955818" z="-161.0245"/>
 					<quaternion qx="7.549801E-08" qy="7.589671E-07" qz="-1" qw="-1.509957E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
@@ -8,10 +8,10 @@
 	  </offset>
 	 </connection>
 	</add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium standard highpower platformcollision missile symmetry symmetry_left symmetry_2 terronly </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard highpower platformcollision symmetry symmetry_left symmetry_3 terronly </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard highpower platformcollision missile symmetry symmetry_right symmetry_2 terronly </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard highpower platformcollision symmetry symmetry_right symmetry_3 terronly </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium standard highpower platformcollision missile symmetry symmetry_left symmetry_2 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard highpower platformcollision symmetry symmetry_left symmetry_3 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard highpower platformcollision missile symmetry symmetry_right symmetry_2 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard highpower platformcollision symmetry symmetry_right symmetry_3 terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1315,12 +1315,12 @@
 					<position x="0" y="23.75786" z="30.97534"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_front" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_front" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="0" y="5.034733" z="16.41826"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_mid" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_mid" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="0" y="5.034733" z="-12.30429"/>
 				</offset>
@@ -1388,22 +1388,22 @@
 					<position x="2.002491" y="-3.123066" z="63.01083"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_2 ">
+			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="19.20162" y="1.103082" z="28.07042"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 ">
+			<connection name="con_weapon_02" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 combat">
 				<offset>
 					<position x="17.74879" y="-6.977129" z="30.10943"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_2 ">
+			<connection name="con_weapon_04" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="-19.20162" y="1.103082" z="28.07042"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 ">
+			<connection name="con_weapon_03" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 combat">
 				<offset>
 					<position x="-17.74879" y="-6.977129" z="30.10943"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
@@ -1285,7 +1285,7 @@
 					<quaternion qx="0.707107" qy="-2.009719E-14" qz="6.181724E-08" qw="-0.7071065"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium platformcollision ">
+			<connection name="con_engine_01" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="-9.561062" y="-2.461639" z="-50.86693"/>
 				</offset>
@@ -1413,7 +1413,7 @@
 					<position x="12.33992" y="3.809264" z="-44.36585"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium platformcollision ">
+			<connection name="con_engine_02" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="9.561062" y="-2.461639" z="-50.86692"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_corvette_01.xml
@@ -1300,7 +1300,7 @@
 					<position x="0" y="23.85275" z="36.06744"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_01" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="-12.33992" y="3.759263" z="-44.36584"/>
 				</offset>
@@ -1408,7 +1408,7 @@
 					<position x="-17.74879" y="-6.977129" z="30.10943"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_02" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="12.33992" y="3.809264" z="-44.36585"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
@@ -8,10 +8,10 @@
 	  </offset>
 	 </connection>
 	</add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 terronly </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 terronly </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1409,13 +1409,13 @@
 					<position x="0" y="23.75786" z="30.97534"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_l" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_l" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-23.40182" y="-6.120095" z="13.13328"/>
 					<quaternion qx="-7.384387E-02" qy="-4.984419E-02" qz="-0.8070452" qw="-0.5837299"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_r" tags="turret medium standard missile platformcollision unhittable ">
+			<connection name="con_turret_r" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="23.40182" y="-6.120095" z="13.13328"/>
 					<quaternion qx="-7.384329E-02" qy="4.984432E-02" qz="0.8070448" qw="-0.5837305"/>
@@ -1489,22 +1489,22 @@
 					<quaternion qx="-2.955989E-06" qy="-0.3007057" qz="9.320198E-07" qw="-0.9537169"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_2 ">
+			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="5.628656" y="-9.000001" z="35.16343"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 ">
+			<connection name="con_weapon_03" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_left symmetry_3 combat">
 				<offset>
 					<position x="4.448088" y="0" z="50.98108"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_2 ">
+			<connection name="con_weapon_02" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="-5.628656" y="-9" z="35.16343"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 ">
+			<connection name="con_weapon_04" tags="weapon medium standard highpower missile platformcollision symmetry symmetry_right symmetry_3 combat">
 				<offset>
 					<position x="-4.448088" y="0" z="50.98108"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
@@ -1393,7 +1393,7 @@
 					<position x="0" y="23.85275" z="36.06744"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_01" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="-10.9035" y="-17.6915" z="-27.258"/>
 					<quaternion qx="-1" qy="4.371131E-08" qz="4.371147E-08" qw="-1.732503E-06"/>
@@ -1509,7 +1509,7 @@
 					<position x="-4.448088" y="0" z="50.98108"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable platformcollision ">
+			<connection name="con_shield_02" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="10.9035" y="-17.6915" z="-27.258"/>
 					<quaternion qx="-1" qy="4.371131E-08" qz="4.371147E-08" qw="-1.732503E-06"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_frigate_01.xml
@@ -1377,7 +1377,7 @@
 					<quaternion qx="0.6427875" qy="5.387734E-09" qz="6.1582E-08" qw="-0.7660446"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium platformcollision ">
+			<connection name="con_engine_01" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="-29.91887" y="6.854845" z="-36.88498"/>
 					<quaternion qx="-0" qy="-0" qz="-0.9762961" qw="-0.2164392"/>
@@ -1515,31 +1515,31 @@
 					<quaternion qx="-1" qy="4.371131E-08" qz="4.371147E-08" qw="-1.732503E-06"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_002" tags="engine medium platformcollision ">
+			<connection name="con_engine_002" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="-18.93528" y="1.733114" z="-43.09187"/>
 					<quaternion qx="-1.811641E-07" qy="1.811641E-07" qz="-0.9762961" qw="-0.2164389"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_003" tags="engine medium platformcollision ">
+			<connection name="con_engine_003" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="-7.985907" y="-3.37266" z="-50.09187"/>
 					<quaternion qx="-1.811641E-07" qy="1.811641E-07" qz="-0.9762961" qw="-0.2164389"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_004" tags="engine medium platformcollision ">
+			<connection name="con_engine_004" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="7.985909" y="-3.372661" z="-50.09185"/>
 					<quaternion qx="2.628181E-18" qy="1.185496E-17" qz="-0.2164396" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_005" tags="engine medium platformcollision ">
+			<connection name="con_engine_005" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="18.93528" y="1.733109" z="-43.09185"/>
 					<quaternion qx="2.628181E-18" qy="1.185496E-17" qz="-0.2164396" qw="-0.976296"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_006" tags="engine medium platformcollision ">
+			<connection name="con_engine_006" tags="engine medium platformcollision standard">
 				<offset>
 					<position x="29.91887" y="6.854847" z="-36.88497"/>
 					<quaternion qx="2.628181E-18" qy="1.185496E-17" qz="-0.2164396" qw="-0.976296"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
@@ -8,7 +8,7 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium highpower missile platformcollision terronly  </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags">weapon medium highpower missile platformcollision terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1368,7 +1368,7 @@
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_01" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="-12.54491" y="7.470922" z="-31.31257"/>
 					<quaternion qx="-0" qy="-0" qz="-6.975656E-02" qw="-0.9975641"/>
@@ -1385,7 +1385,7 @@
 					<position x="0" y="-9.859221" z="-37.25963"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_02" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="12.54491" y="7.470922" z="-31.31256"/>
 					<quaternion qx="-0" qy="-0" qz="6.975651E-02" qw="-0.9975641"/>
@@ -1454,25 +1454,25 @@
 					<position x="1.251469" y="20.51945" z="11.28745"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_03" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="-13.893" y="1" z="19.53765"/>
 					<quaternion qx="-0" qy="-0" qz="-0.1305262" qw="-0.9914448"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_04" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="13.893" y="1" z="19.53765"/>
 					<quaternion qx="1.402615E-07" qy="1.402615E-07" qz="0.130526" qw="-0.9914449"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_05" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="-12.093" y="1" z="41.9988"/>
 					<quaternion qx="-0" qy="-0" qz="-0.1305262" qw="-0.9914448"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_06" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="12.093" y="1" z="41.9988"/>
 					<quaternion qx="-3.165416E-07" qy="3.165416E-07" qz="0.130526" qw="-0.9914449"/>
@@ -1484,7 +1484,7 @@
 					<quaternion qx="1.49704E-07" qy="-1.970894E-08" qz="-0.9914448" qw="0.1305264"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision ">
+			<connection name="con_weapon_01" tags="weapon medium standard highpower missile platformcollision combat">
 				<offset>
 					<position x="0" y="0" z="63"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
@@ -1362,7 +1362,7 @@
 					<quaternion qx="-0.9914448" qy="0.1305264" qz="4.333743E-08" qw="-5.705491E-09"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ">
+			<connection name="con_engine_01" tags="engine medium standard">
 				<offset>
 					<position x="-9.385995" y="2.929081E-02" z="-39.2111"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
@@ -1391,7 +1391,7 @@
 					<quaternion qx="-0" qy="-0" qz="6.975651E-02" qw="-0.9975641"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium ">
+			<connection name="con_engine_02" tags="engine medium standard">
 				<offset>
 					<position x="9.385995" y="2.929081E-02" z="-39.2111"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_gunboat_01.xml
@@ -1356,7 +1356,7 @@
 					<position x="1.251469" y="20.33785" z="6.611723"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable ">
+			<connection name="con_shield_01" tags="medium shield unhittable standard">
 				<offset>
 					<position x="-9.709114" y="-4.00605" z="30.88029"/>
 					<quaternion qx="-0.9914448" qy="0.1305264" qz="4.333743E-08" qw="-5.705491E-09"/>
@@ -1478,7 +1478,7 @@
 					<quaternion qx="-3.165416E-07" qy="3.165416E-07" qz="0.130526" qw="-0.9914449"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="medium shield unhittable ">
+			<connection name="con_shield_02" tags="medium shield unhittable standard">
 				<offset>
 					<position x="9.709114" y="-4.00605" z="30.88029"/>
 					<quaternion qx="1.49704E-07" qy="-1.970894E-08" qz="-0.9914448" qw="0.1305264"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
@@ -1514,7 +1514,7 @@
 					<quaternion qx="8.859751E-02" qy="-4.459601E-08" qz="8.005266E-09" qw="-0.9960675"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ">
+			<connection name="con_engine_01" tags="engine medium standard">
 				<offset>
 					<position x="-7.783809" y="-1.077707" z="-32.65578"/>
 				</offset>
@@ -1542,7 +1542,7 @@
 					<quaternion qx="9.92297E-03" qy="-1.870509E-03" qz="0.3684598" qw="-0.9295889"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium ">
+			<connection name="con_engine_02" tags="engine medium standard">
 				<offset>
 					<position x="7.783811" y="-1.027707" z="-32.60578"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
@@ -1508,7 +1508,7 @@
 					<position x="1.251469" y="20.33785" z="6.611723"/>
 				</offset>
 			</connection>
-			<connection name="con_shield" tags="medium shield unhittable ">
+			<connection name="con_shield" tags="medium shield unhittable standard">
 				<offset>
 					<position x="-3.112894E-03" y="7.872" z="-23.70203"/>
 					<quaternion qx="8.859751E-02" qy="-4.459601E-08" qz="8.005266E-09" qw="-0.9960675"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_liquid_01.xml
@@ -1519,7 +1519,7 @@
 					<position x="-7.783809" y="-1.077707" z="-32.65578"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_01" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="-13.08143" y="3.39012" z="-21.02435"/>
 					<quaternion qx="1.010936E-02" qy="2.208915E-03" qz="-0.3600082" qw="-0.9328918"/>
@@ -1536,7 +1536,7 @@
 					<position x="0" y="-6.491763" z="-23.23618"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_02" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="13.08143" y="3.390117" z="-21.02434"/>
 					<quaternion qx="9.92297E-03" qy="-1.870509E-03" qz="0.3684598" qw="-0.9295889"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
@@ -1575,7 +1575,7 @@
 					<quaternion qx="8.859751E-02" qy="-4.459601E-08" qz="8.005266E-09" qw="-0.9960675"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ">
+			<connection name="con_engine_01" tags="engine medium standard">
 				<offset>
 					<position x="-7.783809" y="-1.077707" z="-32.65578"/>
 				</offset>
@@ -1603,7 +1603,7 @@
 					<quaternion qx="9.92297E-03" qy="-1.870509E-03" qz="0.3684598" qw="-0.9295889"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium ">
+			<connection name="con_engine_02" tags="engine medium standard">
 				<offset>
 					<position x="7.783811" y="-1.027707" z="-32.60578"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
@@ -1569,7 +1569,7 @@
 					<position x="1.251469" y="20.33785" z="6.611723"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable ">
+			<connection name="con_shield_01" tags="medium shield unhittable standard">
 				<offset>
 					<position x="-3.112894E-03" y="7.872" z="-23.70203"/>
 					<quaternion qx="8.859751E-02" qy="-4.459601E-08" qz="8.005266E-09" qw="-0.9960675"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_miner_solid_01.xml
@@ -1580,7 +1580,7 @@
 					<position x="-7.783809" y="-1.077707" z="-32.65578"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" tags="turret medium standard missile mining unhittable ">
+			<connection name="con_turret_01" tags="turret medium standard missile mining unhittable combat">
 				<offset>
 					<position x="-13.08143" y="3.39012" z="-21.02435"/>
 					<quaternion qx="1.010936E-02" qy="2.208915E-03" qz="-0.3600082" qw="-0.9328918"/>
@@ -1597,7 +1597,7 @@
 					<position x="0" y="-6.491763" z="-23.23618"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" tags="turret medium standard missile mining unhittable ">
+			<connection name="con_turret_02" tags="turret medium standard missile mining unhittable combat">
 				<offset>
 					<position x="13.08143" y="3.390117" z="-21.02434"/>
 					<quaternion qx="9.92297E-03" qy="-1.870509E-03" qz="0.3684598" qw="-0.9295889"/>
@@ -1619,7 +1619,7 @@
 					<position x="7.331014E-03" y="6.734101" z="8.452146"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon medium standard missile mining platformcollision ">
+			<connection name="con_weapon_01" tags="weapon medium standard missile mining platformcollision combat">
 				<offset>
 					<position x="0" y="2.123214" z="11.11067"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
@@ -1362,7 +1362,7 @@
 					<position x="1.251469" y="20.33785" z="6.611723"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="medium shield unhittable ">
+			<connection name="con_shield_01" tags="medium shield unhittable standard">
 				<offset>
 					<position x="0" y="-7.553785" z="30.34093"/>
 					<quaternion qx="-1" qy="1.192488E-08" qz="4.371139E-08" qw="-5.212531E-16"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
@@ -1374,7 +1374,7 @@
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_01" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="-12.54491" y="7.470922" z="-31.31257"/>
 					<quaternion qx="-0" qy="-0" qz="-6.975656E-02" qw="-0.9975641"/>
@@ -1391,7 +1391,7 @@
 					<position x="0" y="-9.859221" z="-37.25963"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" tags="turret medium standard missile unhittable ">
+			<connection name="con_turret_02" tags="turret medium standard missile unhittable combat">
 				<offset>
 					<position x="12.54491" y="7.470922" z="-31.31256"/>
 					<quaternion qx="-0" qy="-0" qz="6.975651E-02" qw="-0.9975641"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_ter_m_trans_container_01.xml
@@ -1368,7 +1368,7 @@
 					<quaternion qx="-1" qy="1.192488E-08" qz="4.371139E-08" qw="-5.212531E-16"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ">
+			<connection name="con_engine_01" tags="engine medium standard">
 				<offset>
 					<position x="-9.385995" y="2.929081E-02" z="-39.2111"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>
@@ -1397,7 +1397,7 @@
 					<quaternion qx="-0" qy="-0" qz="6.975651E-02" qw="-0.9975641"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine medium ">
+			<connection name="con_engine_02" tags="engine medium standard">
 				<offset>
 					<position x="9.385995" y="2.929081E-02" z="-39.2111"/>
 					<quaternion qx="-0" qy="-0" qz="-1" qw="7.54979E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
@@ -1106,7 +1106,7 @@
 					<position x="11.945" y="-7.00084" z="31.47911"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_front_R" tags="medium shield unhittable platformcollision">
+			<connection name="con_shield_front_R" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="7.395149" y="-6.359723" z="-18.9089"/>
 					<quaternion qx="-1.421557E-15" qy="1.192093E-07" qz="-1" qw="1.192488E-08"/>
@@ -1117,7 +1117,7 @@
 					<position x="8.34465E-07" y="0.3275747" z="-29.86381"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_front_L" tags="medium shield unhittable platformcollision">
+			<connection name="con_shield_front_L" tags="medium shield unhittable platformcollision standard">
 				<offset>
 					<position x="-7.442429" y="-6.359723" z="-18.9089"/>
 					<quaternion qx="-1.421557E-15" qy="1.192093E-07" qz="-1" qw="1.192488E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
@@ -9,11 +9,11 @@
 	 </connection>
 	</add>
 
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_05']/@tags"> weapon medium standard highpower terronly platformcollision symmetry symmetry_left symmetry_1 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon medium standard highpower terronly platformcollision </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard highpower terronly platformcollision symmetry symmetry_right symmetry_1 </replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_05']/@tags"> weapon medium standard highpower terronly platformcollision symmetry symmetry_left symmetry_1 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_04']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_03']/@tags"> weapon medium standard highpower terronly platformcollision combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_02']/@tags"> weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_primaryweapon_01']/@tags"> weapon medium standard highpower terronly platformcollision symmetry symmetry_right symmetry_1 combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1079,13 +1079,13 @@
 					<position x="7.105427E-15" y="0.3361132" z="16.17508"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_L01" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="-14.52599" y="-5.033207E-02" z="-21.14665"/>
 					<quaternion qx="1.083347E-08" qy="4.043106E-08" qz="-0.258819" qw="-0.9659259"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_04" tags="weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2">
+			<connection name="con_primaryweapon_04" tags="weapon medium standard missile platformcollision symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="-11.94523" y="-7.00084" z="31.47911"/>
 				</offset>
@@ -1095,13 +1095,13 @@
 					<position x="0.1317902" y="14.78893" z="-1.686176"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_R01" tags="turret medium standard missile platformcollision unhittable">
+			<connection name="con_turret_R01" tags="turret medium standard missile platformcollision unhittable combat">
 				<offset>
 					<position x="14.90803" y="-5.033207E-02" z="-21.14665"/>
 					<quaternion qx="-0" qy="-0" qz="0.2588191" qw="-0.9659258"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_02" tags="weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2">
+			<connection name="con_primaryweapon_02" tags="weapon medium standard missile platformcollision symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="11.945" y="-7.00084" z="31.47911"/>
 				</offset>
@@ -1144,17 +1144,17 @@
 					<quaternion qx="-0.7071068" qy="-0" qz="-0" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_03" tags="weapon medium standard missile platformcollision">
+			<connection name="con_primaryweapon_03" tags="weapon medium standard missile platformcollision combat">
 				<offset>
 					<position x="0" y="-7.10223" z="1.28791"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_05" tags="weapon medium standard missile platformcollision symmetry symmetry_left symmetry_1">
+			<connection name="con_primaryweapon_05" tags="weapon medium standard missile platformcollision symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-24.43798" y="-6.506485" z="-11.75323"/>
 				</offset>
 			</connection>
-			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision symmetry symmetry_right symmetry_1 ">
+			<connection name="con_primaryweapon_01" tags="weapon medium standard missile platformcollision symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="24.67099" y="-6.506485" z="-11.75323"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_m/ship_yak_m_corvette_01.xml
@@ -1112,7 +1112,7 @@
 					<quaternion qx="-1.421557E-15" qy="1.192093E-07" qz="-1" qw="1.192488E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine medium ">
+			<connection name="con_engine_01" tags="engine medium standard">
 				<offset>
 					<position x="8.34465E-07" y="0.3275747" z="-29.86381"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
@@ -1053,7 +1053,7 @@
 					<quaternion qx="-1.701514E-05" qy="3.132515E-09" qz="-8.742283E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="0" y="-4.418609E-02" z="-7.277605"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
@@ -9,9 +9,9 @@
 	 </connection>
 	</add>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard highpower terronly </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard highpower terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1107,17 +1107,17 @@
 					<position x="0" y="18.66125" z="-5.618648"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_2">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="9.981528" y="1.08375" z="2.689332"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="9.981528" y="-1.08375" z="2.689332"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-8.793715" y="0" z="-0.5193076"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_01.xml
@@ -1047,7 +1047,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="9.975849" y="0.8804765" z="-4.539765"/>
 					<quaternion qx="-1.701514E-05" qy="3.132515E-09" qz="-8.742283E-08" qw="-1"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
@@ -1108,7 +1108,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="7.490404" y="1.032156" z="6.534771"/>
 					<quaternion qx="-8.18173E-06" qy="-1" qz="4.371139E-08" qw="3.576348E-13"/>
@@ -1183,19 +1183,19 @@
 					<position x="-8.085001" y="0.5031263" z="-4.015613"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="-7.49" y="1.032156" z="6.534771"/>
 					<quaternion qx="8.507571E-06" qy="-1" qz="4.371139E-08" qw="-3.718777E-13"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_03" tags="small shield unhittable ">
+			<connection name="con_shield_03" tags="small shield unhittable standard">
 				<offset>
 					<position x="-8.39" y="1.069203" z="0.8787754"/>
 					<quaternion qx="8.507571E-06" qy="-1" qz="4.371139E-08" qw="-3.718777E-13"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_04" tags="small shield unhittable ">
+			<connection name="con_shield_04" tags="small shield unhittable standard">
 				<offset>
 					<position x="8.390405" y="1.069203" z="0.8774974"/>
 					<quaternion qx="-8.18173E-06" qy="-1" qz="4.371139E-08" qw="3.576348E-13"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
@@ -9,8 +9,8 @@
 	 </connection>
 	</add>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 terronly</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 terronly </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1168,12 +1168,12 @@
 					<position x="0" y="6.517262" z="7.499165"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="7.16775" y="0.503127" z="12.71084"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-7.168" y="0.503127" z="12.71084"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_02.xml
@@ -1114,7 +1114,7 @@
 					<quaternion qx="-8.18173E-06" qy="-1" qz="4.371139E-08" qw="3.576348E-13"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="8.084787" y="0.5031263" z="-4.015613"/>
 				</offset>
@@ -1178,7 +1178,7 @@
 					<position x="-7.168" y="0.503127" z="12.71084"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-8.085001" y="0.5031263" z="-4.015613"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
@@ -1171,13 +1171,13 @@
 					<position x="-9.542356" y="5.958797E-03" z="-8.231298"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="9.550774" y="0.7478139" z="-3.875734"/>
 					<quaternion qx="-1.701514E-05" qy="3.132515E-09" qz="-8.742283E-08" qw="-1"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="-9.551009" y="0.7478139" z="-3.875734"/>
 					<quaternion qx="-1.701514E-05" qy="3.132515E-09" qz="-8.742283E-08" qw="-1"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
@@ -1085,7 +1085,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="0" y="-4.418609E-02" z="-7.277605"/>
 				</offset>
@@ -1161,12 +1161,12 @@
 					<quaternion qx="-0" qy="-0.7071069" qz="-0" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="9.535463" y="5.958796E-03" z="-8.231298"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_03" tags="engine small platformcollision ">
+			<connection name="con_engine_03" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-9.542356" y="5.958797E-03" z="-8.231298"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_fighter_03.xml
@@ -8,8 +8,8 @@
 	  </offset>
 	 </connection>
 	</add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 terronly</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 terronly </replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1139,12 +1139,12 @@
 					<position x="0" y="6.164152" z="-6.138459"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard highpower missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="9.541049" y="0" z="-0.5193076"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard highpower missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-9.548072" y="0" z="-0.5193076"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
@@ -1056,7 +1056,7 @@
 					<quaternion qx="-0.7071127" qy="0.7071009" qz="-3.090836E-08" qw="3.090888E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="7.976157" y="0.4629411" z="-5.020523"/>
 				</offset>
@@ -1130,7 +1130,7 @@
 					<position x="-8.009001" y="-0.6" z="11.7241"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-7.975999" y="0.4629411" z="-5.020523"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
@@ -1050,7 +1050,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="7.509624" y="1.042287" z="5.534769"/>
 					<quaternion qx="-0.7071127" qy="0.7071009" qz="-3.090836E-08" qw="3.090888E-08"/>
@@ -1135,7 +1135,7 @@
 					<position x="-7.975999" y="0.4629411" z="-5.020523"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="-7.51" y="1.042287" z="5.534769"/>
 					<quaternion qx="-0.7071007" qy="-0.7071128" qz="-3.090836E-08" qw="-3.090888E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_heavyfighter_01.xml
@@ -9,10 +9,10 @@
 	 </connection>
 	</add>
 
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision  highpower symmetry symmetry_right symmetry_1 terronly</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 </replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision  highpower symmetry symmetry_left symmetry_1 terronly</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision  highpower symmetry symmetry_right symmetry_1 terronly combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision  highpower symmetry symmetry_left symmetry_1 terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1110,22 +1110,22 @@
 					<position x="0" y="6.517262" z="7.499165"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_2">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="8.00915" y="1.4" z="11.7283"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile highpower symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="8.00915" y="-0.6" z="11.7241"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_2">
+			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="-8.009001" y="1.4" z="11.7283"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile highpower symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-8.009001" y="-0.6" z="11.7241"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
@@ -1047,7 +1047,7 @@
 					<position x="0" y="-1.348155" z="19.35947"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small standard missile mining platformcollision symmetry symmetry_right ">
+			<connection name="con_weapon_01" tags="weapon small standard missile mining platformcollision symmetry symmetry_right combat">
 				<offset>
 					<position x="1.081045E-15" y="1.176422" z="12.22747"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
@@ -970,7 +970,7 @@
 					<quaternion qx="-1" qy="-8.742278E-08" qz="1.424298E-14" qw="1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="0" y="-0.7647955" z="-7.346999"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_miner_solid_01.xml
@@ -964,7 +964,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="0.0295105" y="-1.850444" z="1.607237"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="1.424298E-14" qw="1.629207E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
@@ -957,7 +957,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="6.502784E-17" y="-6.63622" z="-7.486282"/>
 					<quaternion qx="-0.9527907" qy="-8.424717E-08" qz="2.355796E-08" qw="0.3036281"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
@@ -963,7 +963,7 @@
 					<quaternion qx="-0.9527907" qy="-8.424717E-08" qz="2.355796E-08" qw="0.3036281"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="8.081919E-08" y="0.3566103" z="-2.06244"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_01.xml
@@ -8,7 +8,7 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1018,7 +1018,7 @@
 					<position x="0" y="13.58075" z="-5.618648"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower combat">
 				<offset>
 					<position x="0" y="0.9767857" z="4.479788"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
@@ -952,7 +952,7 @@
 					<quaternion qx="-0.9527907" qy="-8.424717E-08" qz="2.355796E-08" qw="0.3036281"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-4.6" y="1.997275" z="0.9123417"/>
 				</offset>
@@ -1011,7 +1011,7 @@
 					<position x="0" y="2.006362" z="4.473331"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="4.6" y="1.997275" z="0.912342"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
@@ -8,7 +8,7 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision missile highpower terronly </replace>
+	<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision missile highpower terronly combat</replace>
 
 	</diff>
 <!-- <components>
@@ -1006,7 +1006,7 @@
 					<position x="0" y="13.58075" z="-5.618648"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile highpower combat">
 				<offset>
 					<position x="0" y="2.006362" z="4.473331"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_scout_02.xml
@@ -946,7 +946,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="6.502784E-17" y="-6.63622" z="-7.486282"/>
 					<quaternion qx="-0.9527907" qy="-8.424717E-08" qz="2.355796E-08" qw="0.3036281"/>
@@ -1016,7 +1016,7 @@
 					<position x="4.6" y="1.997275" z="0.912342"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_02" tags="small shield unhittable ">
+			<connection name="con_shield_02" tags="small shield unhittable standard">
 				<offset>
 					<position x="6.502784E-17" y="4.363853" z="2.239721"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_trans_container_01.xml
@@ -970,7 +970,7 @@
 					<quaternion qx="-1" qy="-8.742278E-08" qz="1.424298E-14" qw="1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="0" y="-0.7647955" z="-7.346999"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_trans_container_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_ter_s_trans_container_01.xml
@@ -964,7 +964,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="0.0295105" y="-1.850444" z="1.607237"/>
 					<quaternion qx="-1" qy="-8.742278E-08" qz="1.424298E-14" qw="1.629207E-07"/>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
@@ -8,10 +8,10 @@
 	  </offset>
 	 </connection>
 	</add>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1</replace>
-<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_02']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_04']/@tags"> weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_01']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat</replace>
+<replace  sel="/components/component/connections/connection[@name='con_weapon_03']/@tags"> weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat</replace>
 
 	</diff>
 
@@ -1280,22 +1280,22 @@
 					<quaternion qx="-0" qy="-0.7071069" qz="-0" qw="-0.7071066"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 ">
+			<connection name="con_weapon_02" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_1 combat">
 				<offset>
 					<position x="-9.821655" y="-1.432474" z="-6.20505"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 ">
+			<connection name="con_weapon_04" tags="weapon small platformcollision standard missile symmetry symmetry_left symmetry_2 combat">
 				<offset>
 					<position x="-7.821657" y="-1.432474" z="-5.20505"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 ">
+			<connection name="con_weapon_01" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_1 combat">
 				<offset>
 					<position x="9.821999" y="-1.432474" z="-6.20505"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 ">
+			<connection name="con_weapon_03" tags="weapon small platformcollision standard missile symmetry symmetry_right symmetry_2 combat">
 				<offset>
 					<position x="7.822001" y="-1.432474" z="-5.20505"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
@@ -1200,7 +1200,7 @@
 					<quaternion qx="0.8433914" qy="1.342878E-08" qz="4.327304E-08" qw="-0.5372997"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" tags="engine small platformcollision ">
+			<connection name="con_engine_01" tags="engine small platformcollision standard">
 				<offset>
 					<position x="-4.013842" y="-0.9377359" z="-7.957342"/>
 				</offset>
@@ -1232,7 +1232,7 @@
 					<position x="0.7921258" y="4.366265" z="0.9255996"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_02" tags="engine small platformcollision ">
+			<connection name="con_engine_02" tags="engine small platformcollision standard">
 				<offset>
 					<position x="4.020594" y="-0.9377359" z="-7.96476"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_s/ship_yak_s_fighter_01.xml
@@ -1194,7 +1194,7 @@
 					<quaternion qx="-0" qy="0.7071068" qz="-0" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_shield_01" tags="small shield unhittable ">
+			<connection name="con_shield_01" tags="small shield unhittable standard">
 				<offset>
 					<position x="0" y="-1.203412" z="-8.026274"/>
 					<quaternion qx="0.8433914" qy="1.342878E-08" qz="4.327304E-08" qw="-0.5372997"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
@@ -1267,7 +1267,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="121.427" y="36.74385" z="-375.8907"/>
 				</offset>
@@ -1294,18 +1294,18 @@
 					<position x="9.999985" y="116.929" z="-1295.598"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 					<position x="-121.427" y="36.74385" z="-375.8907"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_03" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_03" tags="extralarge shield standard">
 				<offset>
 					<position x="-125" y="-68.34391" z="-732.5822"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_04" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_04" tags="extralarge shield standard">
 				<offset>
 					<position x="125" y="-68.34391" z="-732.5822"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
@@ -9,14 +9,14 @@
 	  </offset>
 	 </connection>
 	</add>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_16']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_15']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_01']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_02']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_07']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_08']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_11']/@tags"> turret large standard highpower terronly</replace>
-	<replace  sel="/components/component/connections/connection[@name='con_turret_large_12']/@tags"> turret large standard highpower terronly</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_16']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_15']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_01']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_02']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_07']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_08']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_11']/@tags">turret large standard highpower terronly combat</replace>
+	<replace  sel="/components/component/connections/connection[@name='con_turret_large_12']/@tags">turret large standard highpower terronly combat</replace>
 </diff>
 <!-- <components>
 	<component name="ship_atf_xl_battleship_01" class="ship_xl">
@@ -1200,13 +1200,13 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_mid_down_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_mid_down_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.545229E-05" y="-142.507" z="-78.3427"/>
 					<quaternion qx="3.258414E-07" qy="1.605357E-06" qz="-1" qw="-4.371087E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_mid_up_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_mid_up_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="11.05674" y="102.8277" z="-344.6298"/>
 				</offset>
@@ -1222,13 +1222,13 @@
 					<quaternion qx="0.7071066" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071069"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.54883E-05" y="-143.7554" z="-98.3427"/>
 					<quaternion qx="1.629208E-07" qy="8.781765E-07" qz="-1" qw="-8.742263E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_mid_up_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_mid_up_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.2104" y="105.063" z="-333.1826"/>
 				</offset>
@@ -1238,7 +1238,7 @@
 					<position x="0" y="86.63132" z="-516"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-10" y="116.929" z="-1295.598"/>
 				</offset>
@@ -1278,18 +1278,18 @@
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_mid_up_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_mid_up_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="38.2104" y="105.063" z="-356.8902"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_mid_down_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_mid_down_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.545229E-05" y="-142.507" z="-138.3427"/>
 					<quaternion qx="3.258414E-07" qy="1.605357E-06" qz="-1" qw="-4.371087E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="9.999985" y="116.929" z="-1295.598"/>
 				</offset>
@@ -1311,32 +1311,32 @@
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_mid_up_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_mid_up_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="90.88316" z="-309.2213"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_mid_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_mid_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-11.057" y="102.8277" z="-344.6298"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_mid_up_left" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_mid_up_left" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="90.88316" z="-285.6227"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_up_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_up_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-38.21" y="105.063" z="-356.8902"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_mid_up_left" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_mid_up_left" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-38.21" y="105.063" z="-333.1826"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_mid_down_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_mid_down_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.54883E-05" y="-143.7554" z="-118.3427"/>
 					<quaternion qx="1.629208E-07" qy="1.116595E-06" qz="-1" qw="-8.742259E-08"/>
@@ -1347,317 +1347,317 @@
 					<position x="2.700806E-02" y="223.2232" z="-81.40008"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_front_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_front_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-247.1506" y="34.16415" z="-143.6097"/>
 					<quaternion qx="0.0590886" qy="-0.7625923" qz="-7.492504E-02" qw="-0.6398029"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_01" group="group_front_up_left_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_01" group="group_front_up_left_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-278.8544" y="29.28957" z="-179.3982"/>
 					<quaternion qx="-0.0726503" qy="0.643344" qz="-6.026801E-02" qw="-0.7597355"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-296.3581" y="30.88893" z="-287.9255"/>
 					<quaternion qx="-7.323134E-02" qy="0.6379413" qz="-6.113507E-02" qw="-0.7641535"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_front_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_front_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-266.6931" y="30.2001" z="-140.2059"/>
 					<quaternion qx="5.883146E-02" qy="-0.7642056" qz="-7.512705E-02" qw="-0.637875"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_front_up_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_front_up_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-277.0664" y="34.72409" z="-291.4734"/>
 					<quaternion qx="6.085622E-02" qy="-0.7666549" qz="-7.348195E-02" qw="-0.6349309"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_02" group="group_front_up_left_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_02" group="group_front_up_left_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-290.2362" y="29.4002" z="-247.9492"/>
 					<quaternion qx="-7.266876E-02" qy="0.6435859" qz="-6.024521E-02" qw="-0.7595307"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_03" group="group_front_up_left_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_03" group="group_front_up_left_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-213.0676" y="21.20179" z="325.976"/>
 					<quaternion qx="-3.787334E-02" qy="0.6453755" qz="-0.0236589" qw="-0.762559"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_front_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_front_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-230.0514" y="23.41558" z="215.7755"/>
 					<quaternion qx="0.6303586" qy="3.994154E-02" qz="-0.7749875" qw="2.114197E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_front_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_front_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-210.2397" y="21.66553" z="365.5034"/>
 					<quaternion qx="0.644224" qy="3.171506E-02" qz="-0.7639749" qw="1.766071E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_front_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_front_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-248.9476" y="21.66267" z="219.438"/>
 					<quaternion qx="0.6372517" qy="3.976524E-02" qz="-0.7693295" qw="2.147025E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_04" group="group_front_up_left_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_04" group="group_front_up_left_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-225.18" y="22.22042" z="255.3409"/>
 					<quaternion qx="-3.786352E-02" qy="0.6456167" qz="-2.366921E-02" qw="-0.7623551"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_front_up_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_front_up_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-229.5605" y="20.36532" z="368.5756"/>
 					<quaternion qx="0.6478572" qy="3.172585E-02" qz="-0.7608964" qw="1.764214E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_17" group="group_front_up_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_17" group="group_front_up_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="248.9476" y="21.66269" z="219.438"/>
 					<quaternion qx="2.147015E-02" qy="0.7693296" qz="3.976501E-02" qw="-0.6372518"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_18" group="group_front_up_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_18" group="group_front_up_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="210.2397" y="21.66555" z="365.5034"/>
 					<quaternion qx="1.766087E-02" qy="0.7639748" qz="3.171586E-02" qw="-0.6442241"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_19" group="group_front_up_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_19" group="group_front_up_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="229.5605" y="20.36534" z="368.5756"/>
 					<quaternion qx="1.764199E-02" qy="0.7608963" qz="3.172629E-02" qw="-0.6478572"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_05" group="group_front_up_right_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_05" group="group_front_up_right_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="225.18" y="22.22044" z="255.3409"/>
 					<quaternion qx="-3.786471E-02" qy="-0.6456167" qz="2.367076E-02" qw="-0.762355"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_06" group="group_front_up_right_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_06" group="group_front_up_right_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="213.0676" y="21.20181" z="325.976"/>
 					<quaternion qx="-3.787147E-02" qy="-0.6453753" qz="2.365815E-02" qw="-0.7625594"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_20" group="group_front_up_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_20" group="group_front_up_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="230.0514" y="23.4156" z="215.7755"/>
 					<quaternion qx="2.114073E-02" qy="0.7749873" qz="3.994101E-02" qw="-0.630359"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_07" group="group_front_up_right_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_07" group="group_front_up_right_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="278.8544" y="29.28959" z="-179.3982"/>
 					<quaternion qx="-7.264917E-02" qy="-0.6433439" qz="6.026789E-02" qw="-0.7597358"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_21" group="group_front_up_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_21" group="group_front_up_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="277.0664" y="34.72412" z="-291.4734"/>
 					<quaternion qx="6.085608E-02" qy="0.766655" qz="7.348145E-02" qw="-0.6349308"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_22" group="group_front_up_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_22" group="group_front_up_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="266.6931" y="30.20012" z="-140.2059"/>
 					<quaternion qx="5.883195E-02" qy="0.7642056" qz="7.512728E-02" qw="-0.6378749"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_23" group="group_front_up_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_23" group="group_front_up_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="296.3581" y="30.88896" z="-287.9255"/>
 					<quaternion qx="-7.323142E-02" qy="-0.6379411" qz="6.113607E-02" qw="-0.7641535"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_08" group="group_front_up_right_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_08" group="group_front_up_right_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="290.2362" y="29.40023" z="-247.9492"/>
 					<quaternion qx="-7.266954E-02" qy="-0.6435857" qz="6.024577E-02" qw="-0.7595308"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_24" group="group_front_up_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_24" group="group_front_up_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="247.1506" y="34.16417" z="-143.6097"/>
 					<quaternion qx="5.908857E-02" qy="0.7625923" qz="7.492538E-02" qw="-0.6398029"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_25" group="group_front_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_25" group="group_front_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-248.9476" y="-21.66267" z="219.438"/>
 					<quaternion qx="3.178269E-02" qy="0.6419652" qz="0.0310221" qw="-0.7654464"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_26" group="group_front_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_26" group="group_front_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-229.5605" y="-20.36532" z="368.5756"/>
 					<quaternion qx="2.419409E-02" qy="0.6422573" qz="2.656833E-02" qw="-0.7656463"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_27" group="group_front_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_27" group="group_front_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-230.0514" y="-23.41558" z="215.7755"/>
 					<quaternion qx="3.994108E-02" qy="0.630359" qz="2.114079E-02" qw="-0.7749873"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_09" group="group_front_down_left_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_09" group="group_front_down_left_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-225.18" y="-22.22042" z="255.3409"/>
 					<quaternion qx="0.6456167" qy="-3.786506E-02" qz="-0.762355" qw="-2.367083E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_10" group="group_front_down_left_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_10" group="group_front_down_left_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-213.0676" y="-21.20179" z="325.976"/>
 					<quaternion qx="0.6453756" qy="-3.787217E-02" qz="-0.7625591" qw="-2.365855E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_28" group="group_front_down_left_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_28" group="group_front_down_left_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-210.2397" y="-21.66553" z="365.5034"/>
 					<quaternion qx="2.421454E-02" qy="0.6422567" qz="2.658548E-02" qw="-0.7656456"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_11" group="group_front_down_left_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_11" group="group_front_down_left_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-290.2362" y="-29.4002" z="-247.9492"/>
 					<quaternion qx="0.6435857" qy="-7.266989E-02" qz="-0.7595307" qw="-6.024583E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_12" group="group_front_down_left_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_12" group="group_front_down_left_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="-278.8544" y="-29.28957" z="-179.3982"/>
 					<quaternion qx="0.6433442" qy="-7.265022E-02" qz="-0.7597354" qw="-0.0602686"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_29" group="group_front_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_29" group="group_front_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-296.3581" y="-30.88893" z="-287.9255"/>
 					<quaternion qx="0.6379414" qy="-7.323165E-02" qz="-0.7641532" qw="-6.113629E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_30" group="group_front_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_30" group="group_front_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-247.1506" y="-34.16415" z="-143.6097"/>
 					<quaternion qx="-0.7625923" qy="5.908877E-02" qz="-0.6398029" qw="-7.492562E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_31" group="group_front_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_31" group="group_front_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-277.0664" y="-34.72409" z="-291.4734"/>
 					<quaternion qx="-0.7666548" qy="6.085638E-02" qz="-0.6349309" qw="-7.348174E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_32" group="group_front_down_left_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_32" group="group_front_down_left_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-266.6931" y="-30.2001" z="-140.2059"/>
 					<quaternion qx="-0.7642055" qy="5.883208E-02" qz="-0.637875" qw="-7.512742E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_33" group="group_front_down_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_33" group="group_front_down_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="210.2397" y="-21.66555" z="365.5034"/>
 					<quaternion qx="-0.7639747" qy="-1.766112E-02" qz="0.6442242" qw="-3.171617E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_34" group="group_front_down_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_34" group="group_front_down_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="229.5605" y="-20.36534" z="368.5756"/>
 					<quaternion qx="-0.7608961" qy="-1.764228E-02" qz="0.6478574" qw="-3.172657E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_13" group="group_front_down_right_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_13" group="group_front_down_right_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="225.18" y="-22.22044" z="255.3409"/>
 					<quaternion qx="-0.6456165" qy="-3.786458E-02" qz="-0.7623551" qw="2.367065E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_14" group="group_front_down_right_2" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_14" group="group_front_down_right_2" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="213.0676" y="-21.20181" z="325.976"/>
 					<quaternion qx="-0.6453751" qy="-3.787208E-02" qz="-0.7625595" qw="2.365866E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_35" group="group_front_down_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_35" group="group_front_down_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="248.9476" y="-21.66269" z="219.438"/>
 					<quaternion qx="-0.7693297" qy="-2.147012E-02" qz="0.6372516" qw="-3.976493E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_36" group="group_front_down_right_2" tags="medium shield hittable ">
+			<connection name="con_shieldgen_36" group="group_front_down_right_2" tags="medium shield hittable standard ">
 				<offset>
 					<position x="230.0514" y="-23.4156" z="215.7755"/>
 					<quaternion qx="-0.7749875" qy="-2.114068E-02" qz="0.6303588" qw="-3.994096E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_37" group="group_front_down_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_37" group="group_front_down_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="296.3581" y="-30.88896" z="-287.9255"/>
 					<quaternion qx="-0.6379415" qy="-7.323162E-02" qz="-0.7641532" qw="6.113628E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_38" group="group_front_down_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_38" group="group_front_down_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="277.0664" y="-34.72412" z="-291.4734"/>
 					<quaternion qx="-0.7666548" qy="-6.085637E-02" qz="0.6349309" qw="-7.348174E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_15" group="group_front_down_right_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_15" group="group_front_down_right_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="278.8544" y="-29.28959" z="-179.3982"/>
 					<quaternion qx="-0.6433437" qy="-7.264977E-02" qz="-0.7597358" qw="6.026838E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_39" group="group_front_down_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_39" group="group_front_down_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="266.6931" y="-30.20012" z="-140.2059"/>
 					<quaternion qx="-0.7642055" qy="-5.883206E-02" qz="0.637875" qw="-7.512739E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_large_16" group="group_front_down_right_1" tags="turret large standard missile hittable ">
+			<connection name="con_turret_large_16" group="group_front_down_right_1" tags="turret large standard missile hittable combat">
 				<offset>
 					<position x="290.2362" y="-29.40023" z="-247.9492"/>
 					<quaternion qx="-0.6435856" qy="-7.266907E-02" qz="-0.759531" qw="6.024535E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_40" group="group_front_down_right_1" tags="medium shield hittable ">
+			<connection name="con_shieldgen_40" group="group_front_down_right_1" tags="medium shield hittable standard ">
 				<offset>
 					<position x="247.1506" y="-34.16417" z="-143.6097"/>
 					<quaternion qx="-0.7625923" qy="-5.908861E-02" qz="0.6398028" qw="-7.492544E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_large_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right">
+			<connection name="con_weapon_large_01" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_right combat">
 				<offset>
 					<position x="90" y="0" z="903.1666"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_large_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_left">
+			<connection name="con_weapon_large_02" tags="weapon large standard ter_destroyer_01 symmetry symmetry_1 symmetry_left combat">
 				<offset>
 					<position x="-90" y="0" z="903.1666"/>
 				</offset>
 			</connection>
-			<connection name="con_weapon_extralarge_01" tags="weapon mandatory extralarge standard atf_battleship_01 ">
+			<connection name="con_weapon_extralarge_01" tags="weapon mandatory extralarge standard atf_battleship_01 combat">
 				<offset>
 					<position x="-4.547474E-13" y="15.42134" z="-60.20583"/>
 					<quaternion qx="-7.54979E-08" qy="-7.54979E-08" qz="-1" qw="5.699933E-15"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_41" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_41" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="10" y="-85.34403" z="-1179.484"/>
 					<quaternion qx="1.192092E-07" qy="1.279516E-06" qz="-1" qw="4.371154E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_42" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_42" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-10" y="-85.3363" z="-1179.484"/>
 					<quaternion qx="1.192092E-07" qy="1.279516E-06" qz="-1" qw="4.371154E-08"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_atf_xl_battleship_01.xml
@@ -1272,7 +1272,7 @@
 					<position x="121.427" y="36.74385" z="-375.8907"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge standard">
 				<offset>
 					<position x="0" y="0" z="-1201.098"/>
 					<quaternion qx="-0" qy="-0" qz="-0.7071068" qw="-0.7071067"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
@@ -349,7 +349,7 @@
 					<quaternion qx="-1" qy="-0" qz="-0" qw="1.629207E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge standard">
 				<offset>
 					<position x="-226.7739" y="0" z="-932.5383"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
@@ -343,7 +343,7 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="-223.839" y="-34.95359" z="335.8358"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="1.629207E-07"/>
@@ -381,7 +381,7 @@
 					<quaternion qx="3.258419E-07" qy="-1.255666E-06" qz="-1" qw="4.331254E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_02" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_02" tags="extralarge shield standard">
 				<offset>
 					<position x="-225.765" y="40.45182" z="703.8578"/>
 					<quaternion qx="3.60002E-14" qy="-1" qz="4.768372E-07" qw="7.54979E-08"/>
@@ -614,7 +614,7 @@
 					<position x="-226.752" y="55.07866" z="-815.1046"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_03" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_03" tags="extralarge shield standard">
 				<offset>
 					<position x="-225.7652" y="40.40282" z="477.5508"/>
 				</offset>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_carrier_01.xml
@@ -291,7 +291,7 @@
 					<position x="20.60187" y="183.4671" z="-348.3725"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_30" group="group_back_right_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_30" group="group_back_right_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-119" y="-36.76982" z="-829.2981"/>
 					<quaternion qx="3.258419E-07" qy="-1.255666E-06" qz="-1" qw="4.331254E-07"/>
@@ -308,7 +308,7 @@
 					<quaternion qx="0.6918853" qy="6.31199E-08" qz="6.048653E-08" qw="-0.7220075"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_right_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_right_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-119" y="-36.73372" z="-861.7072"/>
 					<quaternion qx="-7.54968E-08" qy="1.95106E-06" qz="-1" qw="-5.642601E-07"/>
@@ -319,13 +319,13 @@
 					<position x="-230.3759" y="-27.23989" z="754.2822"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_29" group="group_front_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_29" group="group_front_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.1356" y="0" z="660.0283"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_front_left_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_front_left_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-348.021" y="0" z="701.3849"/>
 					<quaternion qx="2.089082E-06" qy="2.08065E-06" qz="-0.7071068" qw="-0.7071068"/>
@@ -354,28 +354,28 @@
 					<position x="-226.7739" y="0" z="-932.5383"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_28" group="group_front_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_28" group="group_front_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="0" z="742.839"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-144.9807" y="41.39259" z="711.6716"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_27" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_27" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-144.9807" y="41.4339" z="782.0801"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_26" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_26" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-144.9807" y="41.4339" z="646.9761"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_25" group="group_back_right_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_25" group="group_back_right_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-119" y="-37.06293" z="-895.6549"/>
 					<quaternion qx="3.258419E-07" qy="-1.255666E-06" qz="-1" qw="4.331254E-07"/>
@@ -387,89 +387,89 @@
 					<quaternion qx="3.60002E-14" qy="-1" qz="4.768372E-07" qw="7.54979E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_mid_left_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_mid_left_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-348.021" y="0" z="136.196"/>
 					<quaternion qx="2.089082E-06" qy="2.08065E-06" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_24" group="group_mid_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_24" group="group_mid_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="0" z="177.6502"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_23" group="group_mid_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_23" group="group_mid_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="0" z="94.83936"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_mid_left_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_mid_left_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-348.021" y="0" z="-224.3305"/>
 					<quaternion qx="2.089082E-06" qy="2.08065E-06" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_22" group="group_mid_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_22" group="group_mid_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="0" z="-182.8764"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_21" group="group_mid_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_21" group="group_mid_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="0" z="-265.6871"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_left_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_left_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-348.021" y="0.7316985" z="-413.3721"/>
 					<quaternion qx="2.089082E-06" qy="2.08065E-06" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_20" group="group_back_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_20" group="group_back_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="-9.710169E-02" z="-371.918"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_19" group="group_back_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_19" group="group_back_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="-8.612108E-02" z="-454.7287"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_back_left_mid" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_back_left_mid" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-348.021" y="0.7316976" z="-815.4963"/>
 					<quaternion qx="-0.4990653" qy="0.4990683" qz="-0.5009299" qw="-0.500933"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_18" group="group_back_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_18" group="group_back_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="-9.710264E-02" z="-774.0421"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_17" group="group_back_left_mid" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_17" group="group_back_left_mid" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-348.138" y="-8.612013E-02" z="-856.8528"/>
 					<quaternion qx="3.582522E-07" qy="-1.109893E-07" qz="-0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_back_right_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_back_right_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-119" y="36.73948" z="-861.7072"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_16" group="group_back_right_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_16" group="group_back_right_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-119" y="37.08248" z="-895.6998"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_15" group="group_back_right_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_15" group="group_back_right_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-119" y="36.68729" z="-829.3414"/>
 				</offset>
@@ -486,124 +486,124 @@
 					<quaternion qx="-0.4999997" qy="-0.4999998" qz="-0.5000003" qw="-0.5000002"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_14" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_14" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-301.2909" y="41.43388" z="782.0801"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_13" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_13" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-301.2909" y="41.4339" z="646.9761"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-301.2909" y="41.39259" z="711.6716"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_12" group="group_front_cent_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_12" group="group_front_cent_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-143.5315" y="40.16963" z="248.2679"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_10" group="group_front_cent_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_10" group="group_front_cent_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-144.4274" y="40.04312" z="280.6779"/>
 					<quaternion qx="-2.519492E-03" qy="0.707102" qz="2.449381E-03" qw="-0.7071028"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_11" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_11" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-303.3469" y="40.16963" z="-65.68841"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_11" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_11" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-304.2428" y="40.04312" z="-33.27837"/>
 					<quaternion qx="-2.519492E-03" qy="0.707102" qz="2.449381E-03" qw="-0.7071028"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_10" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-270.9462" y="0" z="491.6923"/>
 					<quaternion qx="-0.7071065" qy="1.303746E-06" qz="1.685878E-07" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_12" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_12" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-298.2087" y="0" z="491.689"/>
 					<quaternion qx="-0.5000008" qy="0.5000008" qz="0.4999992" qw="-0.4999992"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-187.7044" y="0" z="491.6923"/>
 					<quaternion qx="-0.7071065" qy="1.236345E-07" qz="4.019435E-14" qw="-0.707107"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_13" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_13" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-160.171" y="0" z="491.689"/>
 					<quaternion qx="0.5000001" qy="-0.5000001" qz="-0.4999999" qw="0.4999999"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-122" y="-36.81911" z="275.8569"/>
 					<quaternion qx="-1" qy="-1.192487E-08" qz="-1.192489E-08" qw="-8.026785E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_14" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_14" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-122" y="-36.68668" z="309.0517"/>
 					<quaternion qx="-1" qy="-1.509958E-07" qz="-1.800607E-15" qw="-1.192488E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-122" y="-36.81911" z="344.8457"/>
 					<quaternion qx="-1" qy="-1.192487E-08" qz="-1.192489E-08" qw="-8.026785E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-300" y="-36.78921" z="275.8569"/>
 					<quaternion qx="-1" qy="-1.192487E-08" qz="-1.192489E-08" qw="-8.026785E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_front_mid_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_front_mid_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-300" y="-36.78921" z="344.8457"/>
 					<quaternion qx="-1" qy="-1.192487E-08" qz="-1.192489E-08" qw="-8.026785E-07"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_15" group="group_front_mid_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_15" group="group_front_mid_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-300" y="-36.65678" z="309.0517"/>
 					<quaternion qx="-1" qy="-1.509958E-07" qz="-1.800607E-15" qw="-1.192488E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_16" group="group_mid_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_16" group="group_mid_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="347.5748" y="-1.183225" z="30.30241"/>
 					<quaternion qx="1.41474E-06" qy="1.38099E-06" qz="0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_mid_mid_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_mid_mid_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="348.138" y="-1.183225" z="48.18822"/>
 					<quaternion qx="1.827942E-03" qy="-1.82804E-03" qz="0.7071044" qw="-0.7071044"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_17" group="group_mid_mid_right" tags="medium shield hittable ">
+			<connection name="con_shieldgen_17" group="group_mid_mid_right" tags="medium shield hittable standard ">
 				<offset>
 					<position x="347.5748" y="-1.183225" z="83.88923"/>
 					<quaternion qx="1.583328E-06" qy="1.212403E-06" qz="0.7071068" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_mid_mid_right" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_mid_mid_right" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="348.138" y="-1.183225" z="66.18822"/>
 					<quaternion qx="1.577458E-03" qy="-1.577483E-03" qz="0.707105" qw="-0.707105"/>
@@ -630,25 +630,25 @@
 					<position x="20.60187" y="183.4671" z="-320.749"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_18" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_18" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-314.7669" y="-6.61084" z="-906.8518"/>
 					<quaternion qx="-0.6002485" qy="0.6002486" qz="-0.3737669" qw="0.3737669"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_19" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_19" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-314.8008" y="6.32858" z="-906.9203"/>
 					<quaternion qx="-0.6002486" qy="0.6002484" qz="-0.3737668" qw="0.373767"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_20" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_20" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-129.5009" y="6.328579" z="-907.1893"/>
 					<quaternion qx="0.3823113" qy="-0.3823113" qz="0.594843" qw="-0.5948429"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_21" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_21" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-128.9053" y="-6.61084" z="-907.1893"/>
 					<quaternion qx="0.3823113" qy="-0.3823113" qz="0.594843" qw="-0.5948429"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
@@ -252,13 +252,13 @@
 					<quaternion qx="0.5" qy="-0.5" qz="0.5" qw="-0.5"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_01" group="group_cent_cent_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_01" group="group_cent_cent_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-54.41034" z="89.21645"/>
 					<quaternion qx="-0.9996092" qy="-4.336092E-08" qz="-1.314225E-08" qw="-2.795683E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_01" group="group_back_cent_up" tags="medium shield hittable ">
+			<connection name="con_shieldgen_01" group="group_back_cent_up" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="101.1595" z="-802.5206"/>
 					<quaternion qx="9.511893E-03" qy="-0" qz="-0" qw="-0.9999548"/>
@@ -275,25 +275,25 @@
 					<quaternion qx="0.7071067" qy="-1.067702E-07" qz="-1.067701E-07" qw="-0.7071068"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_02" group="group_cent_cent_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_02" group="group_cent_cent_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="-55.19547" z="72.44033"/>
 					<quaternion qx="-0.9996091" qy="-8.73886E-08" qz="-2.444052E-09" qw="-0.0279567"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_02" group="group_back_cent_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_02" group="group_back_cent_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="15.736" y="101.3139" z="-802.559"/>
 					<quaternion qx="9.51198E-03" qy="-1.495527E-07" qz="-1.524253E-07" qw="-0.9999548"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_03" group="group_back_right_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_03" group="group_back_right_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="20.46" y="-63.16881" z="-744.6482"/>
 					<quaternion qx="-0.5991694" qy="-0.3751196" qz="-0.5948353" qw="0.3826909"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_03" group="group_back_right_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_03" group="group_back_right_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="20.773" y="-61.64658" z="-725.6135"/>
 					<quaternion qx="4.257807E-03" qy="-4.596775E-03" qz="0.8442826" qw="-0.5358616"/>
@@ -304,31 +304,31 @@
 					<position x="0" y="102.9993" z="-138.4935"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_04" group="group_cent_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_04" group="group_cent_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="107.7426" z="385.4214"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_04" group="group_cent_right_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_04" group="group_cent_right_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="107.3357" z="406.7985"/>
 					<quaternion qx="-4.959952E-05" qy="6.059128E-06" qz="3.513524E-03" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_05" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_05" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-6.590999" y="-71.49486" z="-864.559"/>
 					<quaternion qx="-1" qy="9.090398E-11" qz="3.814697E-06" qw="2.382993E-05"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_05" group="group_back_left_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_05" group="group_back_left_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-20.77271" y="-61.64658" z="-725.6135"/>
 					<quaternion qx="6.149417E-07" qy="7.264218E-07" qz="-0.8571677" qw="-0.5150374"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_06" group="group_back_left_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_06" group="group_back_left_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-20.45969" y="-63.16881" z="-744.6482"/>
 					<quaternion qx="2.038271E-07" qy="7.340329E-07" qz="-0.8571675" qw="-0.5150378"/>
@@ -417,73 +417,73 @@
 					<quaternion qx="-0.7210415" qy="-5.231189E-08" qz="-0.692892" qw="5.443712E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_06" group="group_back_cent_up" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_06" group="group_back_cent_up" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-15.73565" y="101.3139" z="-802.559"/>
 					<quaternion qx="9.51198E-03" qy="-1.495527E-07" qz="-1.524253E-07" qw="-0.9999548"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_07" group="group_cent_right_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_07" group="group_cent_right_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="107.7426" z="427.9966"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_07" group="group_front_cent_top" tags="medium shield hittable ">
+			<connection name="con_shieldgen_07" group="group_front_cent_top" tags="medium shield hittable standard ">
 				<offset>
 					<position x="0" y="103.3187" z="999.7254"/>
 					<quaternion qx="-4.959952E-05" qy="6.059128E-06" qz="3.513524E-03" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_08" group="group_front_cent_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_08" group="group_front_cent_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="103.5952" z="1017.764"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_09" group="group_front_cent_top" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_09" group="group_front_cent_top" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="103.5952" z="981.7406"/>
 					<quaternion qx="-3.513318E-03" qy="1.712842E-08" qz="-4.149708E-05" qw="-0.9999939"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_10" group="group_cent_cent_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_10" group="group_cent_cent_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="0" y="-56.35341" z="55.79543"/>
 					<quaternion qx="-0.9996092" qy="-4.336092E-08" qz="-1.314225E-08" qw="-2.795683E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_08" group="group_back_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_08" group="group_back_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="6.591001" y="-71.49486" z="-864.559"/>
 					<quaternion qx="-1" qy="-0" qz="-0" qw="-1.192488E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_11" group="group_back_left_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_11" group="group_back_left_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-20.98534" y="-61.76814" z="-763.2681"/>
 					<quaternion qx="4.930256E-07" qy="1.175497E-06" qz="-0.8571677" qw="-0.5150374"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_12" group="group_back_right_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_12" group="group_back_right_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="20.985" y="-61.76814" z="-763.2681"/>
 					<quaternion qx="4.257807E-03" qy="-4.596775E-03" qz="0.8442826" qw="-0.5358616"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_13" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_13" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="5.211787E-16" y="-0.1147938" z="1010.598"/>
 					<quaternion qx="-0.9992055" qy="-4.145729E-05" qz="-1.816556E-06" qw="-3.985287E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_turret_14" group="group_front_mid_down" tags="turret medium standard missile hittable ">
+			<connection name="con_turret_14" group="group_front_mid_down" tags="turret medium standard missile hittable combat">
 				<offset>
 					<position x="-1.959166E-16" y="-2.880482" z="976.2841"/>
 					<quaternion qx="-0.9992055" qy="-4.145729E-05" qz="-1.816556E-06" qw="-3.985287E-02"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_09" group="group_front_mid_down" tags="medium shield hittable ">
+			<connection name="con_shieldgen_09" group="group_front_mid_down" tags="medium shield hittable standard ">
 				<offset>
 					<position x="-1.30474E-17" y="-1.241714" z="993.3729"/>
 					<quaternion qx="-0.9991994" qy="3.510967E-03" qz="1.341438E-04" qw="-3.985261E-02"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
@@ -369,7 +369,7 @@
 					<position x="-1.112991E-03" y="90.85314" z="-512.3962"/>
 				</offset>
 			</connection>
-			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge">
+			<connection name="con_engine_01" group="group_back_mid_down" tags="engine extralarge standard">
 				<offset>
 					<position x="0" y="16.28116" z="-877.1387"/>
 					<quaternion qx="-0" qy="-0" qz="0.7071067" qw="-0.7071068"/>

--- a/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
+++ b/extensions/ego_dlc_terran/assets/units/size_xl/ship_ter_xl_resupplier_01.xml
@@ -364,7 +364,7 @@
 					<quaternion qx="-0.7071071" qy="5.338506E-08" qz="0.7071065" qw="5.338509E-08"/>
 				</offset>
 			</connection>
-			<connection name="con_shieldgen_xl_01" tags="extralarge shield">
+			<connection name="con_shieldgen_xl_01" tags="extralarge shield standard">
 				<offset>
 					<position x="-1.112991E-03" y="90.85314" z="-512.3962"/>
 				</offset>

--- a/libraries/wares.xml
+++ b/libraries/wares.xml
@@ -5184,7 +5184,7 @@ __________________ -->
     </ware>
 
     <!-- XENON U ENGINE   -->
-    <ware id="engine_xen_xl_u" name="{20107,4034}" description="{20107,4032}" group="engines" transport="equipment" volume="1" tags="engine equipment noplayerblueprint">
+    <ware id="engine_xen_xl_u" name="{20107,4034}" description="{20107,4032}" group="engines" transport="equipment" volume="1" tags="engine equipment noplayerblueprint standard">
       <price min="424138" average="471264" max="518390" />
       <production time="16" amount="1" method="default" name="{20206,101}">
         <primary>
@@ -5200,7 +5200,7 @@ __________________ -->
     </ware>
 
     <!-- split medium large engine   -->
-    <ware id="engine_spl_m_large" name="{20107,3084}" description="{20107,3082}" group="engines" transport="equipment" volume="1" tags="engine equipment">
+    <ware id="engine_spl_m_large" name="{20107,3084}" description="{20107,3082}" group="engines" transport="equipment" volume="1" tags="engine equipment standard">
       <price min="258153" average="368448" max="480054" />
       <production time="20" amount="1" method="default" name="{20206,101}">
         <primary>


### PR DESCRIPTION
Hi Shuul,

Thanks for this awesome mod!

I was hoping to help out a bit with the v6 upgrade (partially because I borked my save by saving in v6 and partially because this mod is one of the most important x4 mods to have so I want to help out). As far as I can tell the mod works fine for the most part, the main problem is with the new required tags in v6 making it so that certain parts don't show up as available for certain ship slots. I've done my best to fix this throughout and it does seem to work, although I've only partially tested it as of now (plan to do a bit more today).

Some things that came up that could use your input in addition to the general changes:
- Unsure about the effects of adding the combat tag to Xenon ships
- ship_par_xl_battleship_01 had a bug on [line 434](https://github.com/Shuul/VRO/blob/master/assets/units/size_xl/ship_par_xl_battleship_01.xml#L434) that I fixed
- do weapons even need the combat tag to be added? That commit could be dropped completely if not
- Previously some weapons were "combat" and others were just "standard", now they're all combat so I'm not sure how this changes the balancing
